### PR TITLE
Increase default transposition table size to 32MB

### DIFF
--- a/src/strategy/minimax.rs
+++ b/src/strategy/minimax.rs
@@ -32,14 +32,12 @@ pub struct MinimaxConfig {
     ///
     /// This is an upper limit, the actual memory allocation may be smaller.
     #[cfg_attr(test, strategy(0usize..=1024))]
-    pub table_size: usize,
+    pub hash: usize,
 }
 
 impl Default for MinimaxConfig {
     fn default() -> Self {
-        Self {
-            table_size: 1 << 24,
-        }
+        Self { hash: 1 << 25 }
     }
 }
 
@@ -64,7 +62,7 @@ impl FromStr for MinimaxConfig {
 pub struct Minimax<E: Eval> {
     engine: E,
     #[cfg_attr(test, strategy(any::<MinimaxConfig>()
-        .prop_map(|c| TranspositionTable::new(c.table_size)))
+        .prop_map(|c| TranspositionTable::new(c.hash)))
     )]
     tt: TranspositionTable,
 }
@@ -104,7 +102,7 @@ impl<E: Eval> Minimax<E> {
     pub fn with_config(engine: E, config: MinimaxConfig) -> Self {
         Minimax {
             engine,
-            tt: TranspositionTable::new(config.table_size),
+            tt: TranspositionTable::new(config.hash),
         }
     }
 
@@ -349,7 +347,7 @@ mod tests {
     fn table_size_is_an_upper_limit(c: MinimaxConfig) {
         let mm = Minimax::with_config(MockEval::new(), c);
         prop_assume!(mm.tt.capacity() > 1);
-        assert!(mm.tt.size() <= c.table_size);
+        assert!(mm.tt.size() <= c.hash);
     }
 
     #[proptest]


### PR DESCRIPTION

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.098s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:33s
Expected time to finish: 00h:03m:12s
STS rating: 1640

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     25     30     40     39     42     38     25      8     22     41     24     33     33     34     17    451
   Score    355    352    511    485    493    598    387    259    334    512    334    470    429    479    345   6343
Score(%)   35.5   35.2   51.1   48.5   49.3   59.8   38.7   25.9   33.4   51.2   33.4   47.0   42.9   47.9   34.5   42.3
  Rating   1338   1324   2032   1917   1952   2420   1480    910   1244   2037   1244   1850   1667   1890   1293   1640
```