### PR TITLE
Implement the static exchange evaluation algorithm to sort moves

### DIFF
--- a/lib/chess/promotion.rs
+++ b/lib/chess/promotion.rs
@@ -1,3 +1,4 @@
+use super::Role;
 use crate::util::{Binary, Bits};
 use bitvec::{field::BitField, order::Lsb0, view::BitView};
 use derive_more::{Display, Error};
@@ -6,7 +7,7 @@ use test_strategy::Arbitrary;
 use vampirc_uci::UciPiece;
 
 /// A promotion specifier.
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Hash, Arbitrary)]
+#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Arbitrary)]
 pub enum Promotion {
     #[display(fmt = "")]
     None,
@@ -39,6 +40,18 @@ impl Binary for Promotion {
             .into_iter()
             .nth(register.load())
             .ok_or(DecodePromotionError(register))
+    }
+}
+
+impl From<Promotion> for Option<Role> {
+    fn from(p: Promotion) -> Self {
+        match p {
+            Promotion::None => None,
+            Promotion::Knight => Some(Role::Knight),
+            Promotion::Bishop => Some(Role::Bishop),
+            Promotion::Rook => Some(Role::Rook),
+            Promotion::Queen => Some(Role::Queen),
+        }
     }
 }
 

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -2,7 +2,7 @@ use shakmaty as sm;
 use test_strategy::Arbitrary;
 
 /// Denotes the type of a chess [`Piece`][`super::Piece`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Arbitrary)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Arbitrary)]
 pub enum Role {
     Pawn,
     Knight,

--- a/lib/eval.rs
+++ b/lib/eval.rs
@@ -1,4 +1,3 @@
-use crate::chess::Position;
 use derive_more::{DebugCustom, From};
 use test_strategy::Arbitrary;
 
@@ -12,15 +11,15 @@ pub use pesto::*;
 pub use pst::*;
 pub use random::*;
 
-/// Trait for types that can evaluate a [`Position`].
-pub trait Eval {
-    /// Evaluates a [`Position`].
+/// Trait for types that can evaluate other types.
+pub trait Eval<T> {
+    /// Evaluates an item.
     ///
     /// Positive values favor the current side to play.
-    fn eval(&self, pos: &Position) -> i16;
+    fn eval(&self, item: &T) -> i16;
 }
 
-/// A generic [`Position`] evaluator.
+/// A generic evaluator.
 #[derive(DebugCustom, Clone, Arbitrary, From)]
 pub enum Evaluator {
     #[debug(fmt = "{:?}", _0)]
@@ -37,12 +36,17 @@ impl Default for Evaluator {
     }
 }
 
-impl Eval for Evaluator {
-    fn eval(&self, pos: &Position) -> i16 {
+impl<T> Eval<T> for Evaluator
+where
+    Random: Eval<T>,
+    Materialist: Eval<T>,
+    Pesto: Eval<T>,
+{
+    fn eval(&self, item: &T) -> i16 {
         match self {
-            Evaluator::Random(e) => e.eval(pos),
-            Evaluator::Materialist(e) => e.eval(pos),
-            Evaluator::Pesto(e) => e.eval(pos),
+            Evaluator::Random(e) => e.eval(item),
+            Evaluator::Materialist(e) => e.eval(item),
+            Evaluator::Pesto(e) => e.eval(item),
         }
     }
 }

--- a/lib/eval/materialist.rs
+++ b/lib/eval/materialist.rs
@@ -7,7 +7,7 @@ use test_strategy::Arbitrary;
 pub struct Materialist {}
 
 impl PieceSquareTable for Materialist {
-    const PIECE_VALUE: [i16; 6] = [100, 300, 300, 500, 900, 0];
+    const PIECE_VALUE: [i16; 6] = [100, 300, 300, 500, 900, 20000];
 }
 
 #[cfg(test)]

--- a/lib/eval/pst.rs
+++ b/lib/eval/pst.rs
@@ -1,5 +1,5 @@
 use super::Eval;
-use crate::chess::{Color, Piece, Position, Role};
+use crate::chess::{Color, Piece, Position, Promotion, Role};
 
 /// A trait for types that can evaluate positions using a [Piece-Square Table].
 ///
@@ -29,7 +29,7 @@ trait PrecomputedPieceSquareTable: PieceSquareTable {
 
 impl<T: PieceSquareTable> PrecomputedPieceSquareTable for T {}
 
-impl<T: PieceSquareTable> Eval for T {
+impl<T: PieceSquareTable> Eval<Position> for T {
     fn eval(&self, pos: &Position) -> i16 {
         if pos.is_stalemate() || pos.is_material_insufficient() {
             0
@@ -53,5 +53,17 @@ impl<T: PieceSquareTable> Eval for T {
 
             score[pos.turn() as usize] - score[!pos.turn() as usize]
         }
+    }
+}
+
+impl<T: PieceSquareTable> Eval<Role> for T {
+    fn eval(&self, role: &Role) -> i16 {
+        Self::PIECE_VALUE[*role as usize]
+    }
+}
+
+impl<T: PieceSquareTable> Eval<Promotion> for T {
+    fn eval(&self, p: &Promotion) -> i16 {
+        Option::<Role>::from(*p).map(|r| self.eval(&r)).unwrap_or(0)
     }
 }

--- a/lib/eval/random.rs
+++ b/lib/eval/random.rs
@@ -1,5 +1,4 @@
 use super::Eval;
-use crate::chess::Position;
 use derive_more::Constructor;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -9,10 +8,10 @@ use test_strategy::Arbitrary;
 #[derive(Debug, Default, Clone, Arbitrary, Constructor)]
 pub struct Random {}
 
-impl Eval for Random {
-    fn eval(&self, pos: &Position) -> i16 {
+impl<T: Hash> Eval<T> for Random {
+    fn eval(&self, item: &T) -> i16 {
         let mut hashser = DefaultHasher::new();
-        pos.hash(&mut hashser);
+        item.hash(&mut hashser);
         hashser.finish() as i16
     }
 }
@@ -23,7 +22,7 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn score_is_stable(pos: Position) {
-        assert_eq!(Random::new().eval(&pos), Random::new().eval(&pos.clone()));
+    fn score_is_stable(item: String) {
+        assert_eq!(Random::new().eval(&item), Random::new().eval(&item));
     }
 }


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1700:

```
games: 220, challenger: 77.0, defender: 143.0, ΔELO: -107.53812491703198, LOS: 3.2160038326289886e-6
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.092s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:24s
Expected time to finish: 00h:03m:03s
STS rating: 1699

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     29     22     32     39     38     45     26     18     24     42     29     39     37     32     20    472
   Score    399    311    432    482    475    680    384    334    355    528    400    508    445    421    388   6542
Score(%)   39.9   31.1   43.2   48.2   47.5   68.0   38.4   33.4   35.5   52.8   40.0   50.8   44.5   42.1   38.8   43.6
  Rating   1534   1142   1681   1903   1872   2785   1467   1244   1338   2108   1538   2019   1738   1632   1485   1699
```