### PR TITLE
Change null move pruning to use constant R = 3

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -110,6 +110,21 @@ impl Searcher {
         moves
     }
 
+    /// An implementation of [null move pruning].
+    ///
+    /// [null move pruning]: https://www.chessprogramming.org/Null_Move_Pruning
+    fn nmp(&self, pos: &Position, draft: i8) -> Option<i8> {
+        let turn = pos.turn();
+
+        // Avoid common zugzwang positions in which the side to move only has pawns.
+        if draft > 0 && pos.by_color(turn).len() - 1 > pos.by_piece(Piece(turn, Role::Pawn)).len() {
+            const R: i8 = 3;
+            Some((draft - R - 1).max(0))
+        } else {
+            None
+        }
+    }
+
     /// An implementation of [aspiration windows].
     ///
     /// [aspiration windows]: https://www.chessprogramming.org/Aspiration_Windows
@@ -212,14 +227,10 @@ impl Searcher {
                 metrics.sp_cut();
                 return Ok(stand_pat);
             }
-        } else if draft > 0 && *stand_pat >= beta && prev.is_some()
-                // Avoid common zugzwang positions in which the side to move only has pawns.
-                && pos.by_color(pos.turn()).len() - 1 > pos.by_piece(Piece(pos.turn(), Role::Pawn)).len()
-        {
-            let mut pos = pos.clone();
-            if pos.pass().is_ok() {
-                let r = (2 + draft / 8).min(draft - 1);
-                if *-self.nw(None, &pos, -beta, draft - r - 1, time, metrics)? >= beta {
+        } else if *stand_pat >= beta && prev.is_some() {
+            if let Some(d) = self.nmp(pos, draft) {
+                let mut next = pos.clone();
+                if next.pass().is_ok() && *-self.nw(None, &next, -beta, d, time, metrics)? >= beta {
                     metrics.nm_cut();
                     #[cfg(not(test))]
                     // The null move pruning heuristic is not exact.


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1700:

```
games: 190, challenger: 58.5, defender: 131.5, ΔELO: -140.70795469743848, LOS: 4.001372477802079e-8
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.097s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:31s
Expected time to finish: 00h:03m:10s
STS rating: 1724

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     35     19     37     35     39     45     24     15     28     45     27     32     32     49     19    481
   Score    455    256    474    455    495    660    364    313    397    551    391    437    419    599    361   6627
Score(%)   45.5   25.6   47.4   45.5   49.5   66.0   36.4   31.3   39.7   55.1   39.1   43.7   41.9   59.9   36.1   44.2
  Rating   1783    897   1868   1783   1961   2696   1378   1151   1525   2210   1498   1703   1623   2424   1364   1724
```