### PR TITLE
Change SEE to better take positional gain into account

### DIFF
--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -1,6 +1,5 @@
-use super::{Color, Fen, Move, Outcome, Piece, Promotion, Role, San, Square};
+use super::{Color, Fen, Move, Outcome, Piece, Role, San, Square};
 use crate::util::Bits;
-use arrayvec::ArrayVec;
 use bitflags::bitflags;
 use bitvec::{order::Lsb0, view::BitView};
 use derive_more::{DebugCustom, Display, Error};
@@ -224,10 +223,7 @@ impl Position {
     }
 
     /// A series of exchanges on a given [`Square`] ordered by least-value-attacker.
-    pub fn exchanges(
-        &self,
-        s: Square,
-    ) -> impl DoubleEndedIterator<Item = (Role, Promotion)> + ExactSizeIterator {
+    pub fn exchanges(&self, s: Square) -> impl Iterator<Item = Self> {
         let to = s.into();
         let mut pos = self.0.clone();
 
@@ -257,11 +253,8 @@ impl Position {
                 },
             );
 
-            Some((capture.into(), promotion.into()))
+            Some(pos.clone().into())
         })
-        .take(32)
-        .collect::<ArrayVec<_, 32>>()
-        .into_iter()
     }
 
     /// An iterator over the legal [`Move`]s that can be played in this position.


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 1500, challenger: 627.0, defender: 873.0, ΔELO: -57.49868114994132, LOS: 7.397865653402391e-11
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.093s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:25s
Expected time to finish: 00h:03m:04s
STS rating: 1909

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     32     29     41     40     51     49     20     17     25     39     26     43     38     48     26    524
   Score    447    388    542    503    607    691    316    328    367    532    388    594    498    597    453   7251
Score(%)   44.7   38.8   54.2   50.3   60.7   69.1   31.6   32.8   36.7   53.2   38.8   59.4   49.8   59.7   45.3   48.3
  Rating   1747   1485   2170   1997   2460   2834   1164   1218   1391   2126   1485   2402   1974   2415   1774   1909
```