### PR TITLE
Unify stand pat and null move pruning heuristics

### DIFF
--- a/lib/search/metrics.rs
+++ b/lib/search/metrics.rs
@@ -20,7 +20,7 @@ use test_strategy::Arbitrary;
     SubAssign,
 )]
 #[display(
-    fmt = "time={}ms nodes={}|{:.0}/s hits={}|{:.2}% cuts[tt={}|{:.2}% pv={}|{:.2}% nm={}|{:.2}% sp={}|{:.2}%]",
+    fmt = "time={}ms nodes={}|{:.0}/s hits={}|{:.2}% cuts[tt={}|{:.2}% pv={}|{:.2}% nm={}|{:.2}%]",
     "self.time().as_millis()",
     "self.nodes()",
     "self.nps()",
@@ -31,9 +31,7 @@ use test_strategy::Arbitrary;
     "self.pv_cuts()",
     "self.pv_cut_rate() * 100.",
     "self.nm_cuts()",
-    "self.nm_cut_rate() * 100.",
-    "self.sp_cuts()",
-    "self.sp_cut_rate() * 100."
+    "self.nm_cut_rate() * 100."
 )]
 pub struct Metrics {
     time: Duration,
@@ -42,7 +40,6 @@ pub struct Metrics {
     tt_cuts: u64,
     pv_cuts: u64,
     nm_cuts: u64,
-    sp_cuts: u64,
 }
 
 impl Metrics {
@@ -100,16 +97,6 @@ impl Metrics {
     pub fn nm_cut_rate(&self) -> f64 {
         self.nm_cuts() as f64 / self.nodes() as f64
     }
-
-    /// Stand pat cuts counter.
-    pub fn sp_cuts(&self) -> u64 {
-        self.sp_cuts
-    }
-
-    /// Stand pat cut rate.
-    pub fn sp_cut_rate(&self) -> f64 {
-        self.sp_cuts() as f64 / self.nodes() as f64
-    }
 }
 
 /// A collector for search metrics.
@@ -121,7 +108,6 @@ pub struct MetricsCounters {
     tt_cuts: AtomicU64,
     pv_cuts: AtomicU64,
     nm_cuts: AtomicU64,
-    sp_cuts: AtomicU64,
 }
 
 impl Default for MetricsCounters {
@@ -133,7 +119,6 @@ impl Default for MetricsCounters {
             tt_cuts: AtomicU64::new(0),
             pv_cuts: AtomicU64::new(0),
             nm_cuts: AtomicU64::new(0),
-            sp_cuts: AtomicU64::new(0),
         }
     }
 }
@@ -169,11 +154,6 @@ impl MetricsCounters {
         self.nm_cuts.fetch_add(1, Ordering::Relaxed) + 1
     }
 
-    /// Increment stand pat cuts counter.
-    pub fn sp_cut(&self) -> u64 {
-        self.sp_cuts.fetch_add(1, Ordering::Relaxed) + 1
-    }
-
     /// Returns the metrics collected.
     pub fn snapshot(&mut self) -> Metrics {
         Metrics {
@@ -183,7 +163,6 @@ impl MetricsCounters {
             tt_cuts: *self.tt_cuts.get_mut(),
             pv_cuts: *self.pv_cuts.get_mut(),
             nm_cuts: *self.nm_cuts.get_mut(),
-            sp_cuts: *self.sp_cuts.get_mut(),
         }
     }
 }


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 1225, challenger: 593.0, defender: 632.0, ΔELO: -11.064953967248957, LOS: 0.1298198856906433
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.094s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:27s
Expected time to finish: 00h:03m:06s
STS rating: 2084

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     40     31     44     42     50     46     33     21     34     53     31     54     37     49     23    588
   Score    497    418    575    531    588    683    449    357    443    645    437    675    495    637    409   7839
Score(%)   49.7   41.8   57.5   53.1   58.8   68.3   44.9   35.7   44.3   64.5   43.7   67.5   49.5   63.7   40.9   52.3
  Rating   1970   1618   2317   2121   2375   2798   1756   1347   1730   2629   1703   2762   1961   2593   1578   2084

```