### PR TITLE
refine null move pruning with quiescent evaluation

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -270,7 +270,8 @@ impl Searcher {
         let value = match pos.outcome() {
             Some(o) if o.is_draw() => return Ok(Score(0, draft)),
             Some(_) => return Ok(Score(-i16::MAX, draft)),
-            None => self.evaluator.eval(pos).max(-i16::MAX),
+            None if draft <= 0 => self.evaluator.eval(pos).max(-i16::MAX),
+            None => *self.pvs(pos, alpha..beta, 0, time, metrics)?,
         };
 
         if draft <= Self::MIN_DRAFT {


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 1200, challenger: 596.5, defender: 603.5, ΔELO: -2.0267305708029353, LOS: 0.41922977968230274
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.093s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:25s
Expected time to finish: 00h:03m:04s
STS rating: 2117

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     38     35     45     44     53     45     34     19     34     57     37     48     42     53     26    610
   Score    495    439    594    536    607    676    435    348    447    672    463    623    507    658    450   7950
Score(%)   49.5   43.9   59.4   53.6   60.7   67.6   43.5   34.8   44.7   67.2   46.3   62.3   50.7   65.8   45.0   53.0
  Rating   1961   1712   2402   2144   2460   2767   1694   1307   1747   2749   1819   2531   2014   2687   1761   2117
```