### PR TITLE
Refine static evaluation for non-quiescent positions

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -287,10 +287,10 @@ impl Searcher {
             Some(o) if o.is_draw() => return Ok(Score(0, draft)),
             Some(_) => return Ok(Score(-i16::MAX, draft)),
             None if draft <= 0 => self.eval(pos),
-            None => {
-                let guess = transposition.map_or_else(|| alpha / 2 + beta / 2, |t| t.score());
-                *self.aw(pos, guess, alpha..beta, 0, time, metrics)?
-            }
+            None => match transposition {
+                None => *self.nw(pos, beta - 1, 0, time, metrics)?,
+                Some(t) => t.score(),
+            },
         };
 
         if draft <= Self::MIN_DRAFT {


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 1625, challenger: 845.5, defender: 779.5, ΔELO: 14.11899696356004, LOS: 0.950950518979466
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.096s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:30s
Expected time to finish: 00h:03m:09s
STS rating: 2108

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     41     39     48     46     60     49     30     22     31     47     31     53     39     49     21    606
   Score    503    486    610    557    675    688    417    364    426    595    409    649    525    618    397   7919
Score(%)   50.3   48.6   61.0   55.7   67.5   68.8   41.7   36.4   42.6   59.5   40.9   64.9   52.5   61.8   39.7   52.8
  Rating   1997   1921   2473   2237   2762   2820   1614   1378   1654   2406   1578   2647   2095   2509   1525   2108
```