### PR TITLE
Remove check extensions for now

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -310,7 +310,7 @@ impl Searcher {
             }
         }
 
-        let kind = if draft <= 0 && !in_check {
+        let kind = if draft <= 0 {
             MoveKind::CAPTURE | MoveKind::PROMOTION
         } else {
             MoveKind::ANY
@@ -359,11 +359,12 @@ impl Searcher {
                 }
 
                 while *score < alpha && alpha < beta {
-                    let target = alpha;
-                    score = -self.nw(&next, -target - 1, draft - 1, time, metrics)?;
-                    alpha = cutoff.fetch_max(*score, Ordering::Relaxed).max(*score);
-                    if *score < target {
+                    score = -self.nw(&next, -alpha - 1, draft - 1, time, metrics)?;
+
+                    if *score < alpha {
                         break;
+                    } else {
+                        alpha = cutoff.fetch_max(*score, Ordering::Relaxed).max(*score);
                     }
                 }
 
@@ -431,7 +432,7 @@ mod tests {
 
         let kind = if draft <= Searcher::MIN_DRAFT {
             return score;
-        } else if draft <= 0 && !pos.is_check() {
+        } else if draft <= 0 {
             MoveKind::CAPTURE | MoveKind::PROMOTION
         } else {
             MoveKind::ANY


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 2000, challenger: 1070.5, defender: 929.5, ΔELO: 24.53491100901588, LOS: 0.999257446965018
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.095s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:28s
Expected time to finish: 00h:03m:07s
STS rating: 2110

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     36     38     49     45     55     43     29     22     32     54     34     52     42     48     23    602
   Score    484    469    610    565    630    668    395    372    430    652    457    652    525    601    418   7928
Score(%)   48.4   46.9   61.0   56.5   63.0   66.8   39.5   37.2   43.0   65.2   45.7   65.2   52.5   60.1   41.8   52.9
  Rating   1912   1845   2473   2273   2562   2731   1516   1413   1672   2660   1792   2660   2095   2433   1618   2110
```