### PR TITLE
Fix all of quiescent search to draft 0

### DIFF
--- a/lib/transposition/table.rs
+++ b/lib/transposition/table.rs
@@ -72,7 +72,7 @@ impl Table {
 
     /// Stores a [`Transposition`] in the slot associated with `key`.
     ///
-    /// In the slot if not empty, the [`Transposition`] with greater draft is chosen.
+    /// In the slot if not empty, the [`Transposition`] with greater depth is chosen.
     pub fn set(&self, key: Zobrist, transposition: Transposition) {
         let sig = self.signature_of(key);
         let register = Some((transposition, sig)).encode();
@@ -169,7 +169,7 @@ mod tests {
     fn set_ignores_the_signature_mismatch(
         tt: Table,
         t: Transposition,
-        #[filter(#u.draft() > #t.draft())] u: Transposition,
+        #[filter(#u.depth() > #t.depth())] u: Transposition,
         k: Zobrist,
     ) {
         let sig = tt.signature_of((!k.load::<u64>()).view_bits().into());


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 1715, challenger: 920.5, defender: 794.5, ΔELO: 25.57195651865407, LOS: 0.9989049530175356
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.097s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:31s
Expected time to finish: 00h:03m:10s
STS rating: 2152

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     42     37     45     41     55     45     31     22     31     59     33     49     49     51     27    617
   Score    535    447    580    530    636    676    436    375    431    679    470    632    573    632    436   8068
Score(%)   53.5   44.7   58.0   53.0   63.6   67.6   43.6   37.5   43.1   67.9   47.0   63.2   57.3   63.2   43.6   53.8
  Rating   2139   1747   2339   2117   2589   2767   1698   1427   1676   2780   1850   2571   2308   2571   1698   2152
```