### PR TITLE
Slightly tweak aspiration windows

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -206,8 +206,8 @@ impl Searcher {
         assert!(!bounds.is_empty(), "{:?} ≠ ∅", bounds);
         assert!(!bounds.contains(&i16::MIN), "{:?} ∌ {}", bounds, i16::MIN);
 
-        let mut w = 64;
-        if bounds.len() <= w as usize {
+        let mut w = 32;
+        if bounds.len() <= 4 * w as usize {
             return self.pvs(pos, bounds, draft, time, metrics);
         }
 
@@ -218,8 +218,8 @@ impl Searcher {
         loop {
             w = w.saturating_mul(2);
             match self.pvs(pos, lower..upper, draft, time, metrics)? {
-                s if (-lower..-alpha).contains(&-s) => lower = s.saturating_sub(w).max(alpha),
-                s if (upper..beta).contains(&s) => upper = s.saturating_add(w).min(beta),
+                s if (-lower..-alpha).contains(&-s) => lower = s.saturating_sub(w / 2).max(alpha),
+                s if (upper..beta).contains(&s) => upper = s.saturating_add(w / 2).min(beta),
                 s => break Ok(s),
             }
         }


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 700, challenger: 384.0, defender: 316.0, ΔELO: 33.85765669965078, LOS: 0.995390906947902
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.095s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:28s
Expected time to finish: 00h:03m:07s
STS rating: 2137

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     41     33     47     42     54     45     34     23     35     49     27     51     37     57     24    599
   Score    539    451    608    534    623    682    451    399    455    614    391    644    492    673    462   8018
Score(%)   53.9   45.1   60.8   53.4   62.3   68.2   45.1   39.9   45.5   61.4   39.1   64.4   49.2   67.3   46.2   53.5
  Rating   2157   1765   2464   2135   2531   2794   1765   1534   1783   2491   1498   2624   1948   2754   1814   2137
```