### PR TITLE
Adapt null move reductions based on the number of pieces on the board

### DIFF
--- a/benches/ttd.rs
+++ b/benches/ttd.rs
@@ -11,7 +11,7 @@ fn ttd(c: &mut Criterion, fens: &[&str]) {
     c.benchmark_group("benches").bench_function("ttd", |b| {
         b.iter_batched_ref(
             || (Searcher::default(), positions.next().unwrap()),
-            |(s, pos)| s.search::<0>(pos, Limits::Depth(7)),
+            |(s, pos)| s.search::<0>(pos, Limits::Depth(8)),
             BatchSize::SmallInput,
         );
     });

--- a/lib/search.rs
+++ b/lib/search.rs
@@ -162,13 +162,15 @@ impl Searcher {
     /// [null move pruning]: https://www.chessprogramming.org/Null_Move_Pruning
     fn nmp(&self, pos: &Position, value: i16, beta: i16, draft: i8) -> Option<i8> {
         let turn = pos.turn();
+        let r = match pos.by_color(turn).len() - pos.by_piece(Piece(turn, Role::Pawn)).len() {
+            0..=1 => return None,
+            2 => 0,
+            3 => 1,
+            _ => 2,
+        };
 
-        // Avoid common zugzwang positions in which the side to move only has pawns.
-        if value > beta
-            && pos.by_color(turn).len() > pos.by_piece(Piece(turn, Role::Pawn)).len() + 1
-        {
-            let r = 2 + draft.max(0) / 8;
-            Some(draft.saturating_sub(r + 1))
+        if value > beta {
+            Some(draft.saturating_sub(r + 1 + draft.max(0) / 4))
         } else {
             None
         }


### PR DESCRIPTION
## Test results @ time("100ms") / 4 threads

###  Stockfish 15 @ UCI_Elo=1800:

```
games: 2000, challenger: 1147.0, defender: 853.0, ΔELO: 51.44575469349783, LOS: 0.9999999999832885
```

## STS

```
STS Rating v14.0
Number of cores: 16

Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.094s

Number of positions in STS1-STS15_LAN_v3.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:27s
Expected time to finish: 00h:03m:06s
STS rating: 2149

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     41     37     44     49     56     44     36     22     34     52     33     49     42     51     22    612
   Score    542    482    609    583    639    678    460    327    421    630    451    641    529    639    426   8057
Score(%)   54.2   48.2   60.9   58.3   63.9   67.8   46.0   32.7   42.1   63.0   45.1   64.1   52.9   63.9   42.6   53.7
  Rating   2170   1903   2469   2353   2602   2776   1805   1213   1632   2562   1765   2611   2112   2602   1654   2149
```