### PR TITLE
Improve static evaluation

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -243,10 +243,10 @@ impl Searcher {
         let value = match pos.outcome() {
             Some(o) if o.is_draw() => return Ok(Score(0, draft)),
             Some(_) => return Ok(Score(-i16::MAX, draft)),
-            None if draft <= 0 => self.eval(pos),
             None => match transposition {
-                None => *self.nw(pos, beta - 1, 0, timer)?,
                 Some(t) => t.score(),
+                None if draft <= 0 => self.eval(pos),
+                None => *self.nw(pos, beta - 1, 0, timer)?,
             },
         };
 


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1800:

```
games: 10000, wins: 6138, losses: 3720, draws: 142, ΔELO: [+79.94, +94.12]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     37     26     47     43     48     43     34     24     31     52     34     44     37     49     24    573
   Score    594    525    670    668    717    881    608    538    541    774    621    738    591    749    634   9849
Score(%)   59.4   52.5   67.0   66.8   71.7   88.1   60.8   53.8   54.1   77.4   62.1   73.8   59.1   74.9   63.4   65.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 88.1%, "Re-Capturing"
2. STS 10, 77.4%, "Simplification"
3. STS 14, 74.9%, "Queens and Rooks to the 7th rank"
4. STS 12, 73.8%, "Center Control"
5. STS 05, 71.7%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 02, 52.5%, "Open Files and Diagonals"
2. STS 08, 53.8%, "Advancement of f/g/h Pawns"
3. STS 09, 54.1%, "Advancement of a/b/c Pawns"
4. STS 13, 59.1%, "Pawn Play in the Center"
5. STS 01, 59.4%, "Undermining"
```