### PR TITLE
Widen aspiration window at lower depths

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -200,7 +200,14 @@ impl Searcher {
         time: Duration,
         metrics: &MetricsCounters,
     ) -> Result<Score, Timeout> {
-        let mut w = 32;
+        let mut w = match draft {
+            i8::MIN..=1 => 512,
+            2 => 256,
+            3 => 128,
+            4 => 64,
+            _ => 32,
+        };
+
         let (alpha, beta) = (-i16::MAX, i16::MAX);
         let mut lower = guess.saturating_sub(w / 2).clamp(alpha, beta - w);
         let mut upper = guess.saturating_add(w / 2).clamp(alpha + w, beta);


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1800:

```
games: 8000, wins: 4727, losses: 3181, draws: 92, ΔELO: [+61.03, +76.66]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     36     32     35     44     49     41     29     21     31     51     29     45     32     53     22    550
   Score    585    585    595    673    744    882    597    469    513    775    610    756    589    763    636   9772
Score(%)   58.5   58.5   59.5   67.3   74.4   88.2   59.7   46.9   51.3   77.5   61.0   75.6   58.9   76.3   63.6   65.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 88.2%, "Re-Capturing"
2. STS 10, 77.5%, "Simplification"
3. STS 14, 76.3%, "Queens and Rooks to the 7th rank"
4. STS 12, 75.6%, "Center Control"
5. STS 05, 74.4%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 08, 46.9%, "Advancement of f/g/h Pawns"
2. STS 09, 51.3%, "Advancement of a/b/c Pawns"
3. STS 01, 58.5%, "Undermining"
4. STS 02, 58.5%, "Open Files and Diagonals"
5. STS 13, 58.9%, "Pawn Play in the Center"

```