### PR TITLE
Add newtypes for Value and Depth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ derive_more = { version = "0.99.16", default-features = false, features = [
     "add",
     "constructor",
     "deref",
-    "deref_mut",
     "display",
     "error",
     "from",

--- a/benches/ttd.rs
+++ b/benches/ttd.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use lib::search::{Limits, Options, Searcher};
+use lib::search::{Depth, Options, Searcher};
 use lib::{chess::Fen, eval::Evaluator};
 use std::thread::available_parallelism;
 
@@ -25,7 +25,7 @@ fn ttd(c: &mut Criterion, fens: &[&str]) {
                     positions.next().unwrap(),
                 )
             },
-            |(s, pos)| s.search::<0>(pos, Limits::Depth(8)),
+            |(s, pos)| s.search::<0>(pos, Depth::new(8).into()),
             BatchSize::SmallInput,
         );
     });

--- a/benches/ttm.rs
+++ b/benches/ttm.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use lib::search::{Limits, Options, Searcher};
+use lib::search::{Depth, Limits, Options, Searcher};
 use lib::{chess::Fen, eval::Evaluator};
 use shakmaty as sm;
 use std::thread::available_parallelism;
@@ -31,8 +31,8 @@ fn ttm(c: &mut Criterion, name: &str, edps: &[(&str, &str)]) {
                 },
                 |(s, (pos, m))| {
                     let timer = Instant::now();
-                    for d in 1.. {
-                        let pv = s.search::<1>(pos, Limits::Depth(d));
+                    for d in 1..=Depth::MAX.get() {
+                        let pv = s.search::<1>(pos, Limits::Depth(Depth::new(d)));
                         if pv.first() == Some(m) || timer.elapsed() >= Duration::from_millis(80) {
                             break;
                         }

--- a/bin/applet/analyze.rs
+++ b/bin/applet/analyze.rs
@@ -29,8 +29,8 @@ impl Analyze {
                 Option::zip(pv.depth(), pv.score()).context("no principal variation found")?;
 
             info!(
-                depth = d,
-                score = match pos.turn() {
+                depth = %d,
+                score = %match pos.turn() {
                     Color::White => s,
                     Color::Black => -s,
                 },

--- a/bin/applet/uci.rs
+++ b/bin/applet/uci.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Error as Anyhow};
 use clap::Parser;
 use lib::chess::{Fen, Position};
 use lib::eval::Evaluator;
-use lib::search::{Limits, Options, Searcher};
+use lib::search::{Depth, Limits, Options, Searcher};
 use std::num::NonZeroUsize;
 use tokio::io::{stdin, stdout};
 use tokio::task::block_in_place;
@@ -184,7 +184,7 @@ impl<T: Io> Server<T> {
                         warn!("ignored request to terminate the search after {} nodes", n);
                     }
 
-                    self.go(Limits::Depth(depth)).await?;
+                    self.go(Depth::saturate(depth).into()).await?;
                 }
 
                 UciMessage::Unknown(m, cause) => {

--- a/bin/engine/ai.rs
+++ b/bin/engine/ai.rs
@@ -6,6 +6,7 @@ use lib::eval::Evaluator;
 use lib::search::{Limits, Options, Pv};
 use std::{convert::Infallible, time::Instant};
 use tokio::task::block_in_place;
+use tracing::field::display;
 use tracing::{instrument, Span};
 
 #[cfg(test)]
@@ -57,7 +58,9 @@ impl Player for Ai {
             let pv = block_in_place(|| self.strategy.search::<1>(pos, self.limits));
 
             if let Some((d, s)) = Option::zip(pv.depth(), pv.score()) {
-                Span::current().record("depth", d).record("score", s);
+                Span::current()
+                    .record("depth", d)
+                    .record("score", display(s));
             }
 
             Ok(*pv.first().expect("expected at least one legal move"))

--- a/bin/game.rs
+++ b/bin/game.rs
@@ -96,7 +96,7 @@ mod tests {
             fn analyze<'a, 'b, 'c>(
                 &'a mut self,
                 pos: &'b Position,
-            ) -> BoxStream<'c, Result<Pv<10>, String>>
+            ) -> BoxStream<'c, Result<Pv<4>, String>>
             where
                 'a: 'c,
                 'b: 'c;

--- a/lib/eval.rs
+++ b/lib/eval.rs
@@ -4,16 +4,18 @@ use test_strategy::Arbitrary;
 
 mod end;
 mod mid;
+mod value;
 
 pub use end::*;
 pub use mid::*;
+pub use value::*;
 
-/// Trait for types that can evaluate other types.
-pub trait Eval<T> {
-    /// Evaluates an item.
+/// Trait for types that can evaluate [`Position`]s.
+pub trait Eval {
+    /// Evaluates a [`Position`].
     ///
     /// Positive values favor the current side to play.
-    fn eval(&self, item: &T) -> i16;
+    fn eval(&self, item: &Position) -> Value;
 }
 
 /// A tapered evaluator.
@@ -61,8 +63,8 @@ impl Evaluator {
     }
 }
 
-impl Eval<Position> for Evaluator {
-    fn eval(&self, pos: &Position) -> i16 {
+impl Eval for Evaluator {
+    fn eval(&self, pos: &Position) -> Value {
         let turn = pos.turn();
         let phase = self.phase(pos);
 
@@ -75,7 +77,7 @@ impl Eval<Position> for Evaluator {
             }
         }
 
-        score[turn as usize] - score[!turn as usize]
+        Value::saturate(score[turn as usize] - score[!turn as usize])
     }
 }
 

--- a/lib/eval/value.rs
+++ b/lib/eval/value.rs
@@ -1,0 +1,191 @@
+use crate::util::{Binary, Bits};
+use derive_more::{DebugCustom, Display, Error, Neg};
+use num_traits::{clamp, AsPrimitive};
+use std::ops::{Add, Sub};
+use test_strategy::Arbitrary;
+
+#[derive(
+    DebugCustom, Display, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Arbitrary, Neg,
+)]
+#[debug(fmt = "Value({})", self)]
+#[display(fmt = "{:+}", _0)]
+pub struct Value(#[strategy(Self::MIN.get()..=Self::MAX.get())] i16);
+
+impl Value {
+    pub const ZERO: Self = Value(0);
+    pub const MIN: Self = Value(-4095);
+    pub const MAX: Self = Value(4095);
+
+    /// Constructs [`Value`] from a raw value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `v` is outside of the bounds.
+    #[inline]
+    pub fn new(v: i16) -> Self {
+        v.try_into().unwrap()
+    }
+
+    /// Returns the raw value.
+    #[inline]
+    pub fn get(&self) -> i16 {
+        self.0
+    }
+
+    /// Safely constructs [`Value`] from a raw value through saturation.
+    #[inline]
+    pub fn saturate<T: AsPrimitive<i16> + From<i16> + PartialOrd>(i: T) -> Self {
+        Value(clamp(i, Self::MIN.get().into(), Self::MAX.get().into()).as_())
+    }
+}
+
+/// The reason why converting [`Value`] from an integer failed.
+#[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
+#[display(
+    fmt = "expected integer in the range `({}..={})`",
+    Value::MIN,
+    Value::MAX
+)]
+pub struct ValueOutOfRange;
+
+impl TryFrom<i16> for Value {
+    type Error = ValueOutOfRange;
+
+    #[inline]
+    fn try_from(v: i16) -> Result<Self, Self::Error> {
+        if (Value::MIN.get()..=Value::MAX.get()).contains(&v) {
+            Ok(Value(v))
+        } else {
+            Err(ValueOutOfRange)
+        }
+    }
+}
+
+impl Add<i16> for Value {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: i16) -> Self::Output {
+        Value::saturate(self.get().saturating_add(rhs))
+    }
+}
+
+impl Add for Value {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        self + rhs.get()
+    }
+}
+
+impl Sub<i16> for Value {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: i16) -> Self::Output {
+        Value::saturate(self.get().saturating_sub(rhs))
+    }
+}
+
+impl Sub for Value {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        self - rhs.get()
+    }
+}
+
+/// The reason why decoding [`Value`] from binary failed.
+#[derive(Debug, Display, Clone, Eq, PartialEq, Arbitrary, Error)]
+#[display(fmt = "not a valid Value")]
+pub struct DecodeValueError;
+
+impl Binary for Value {
+    type Bits = Bits<u16, 13>;
+    type Error = DecodeValueError;
+
+    fn encode(&self) -> Self::Bits {
+        Bits::new((self.0 - Self::MIN.get()) as _)
+    }
+
+    fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
+        if bits == !Bits::default() {
+            Err(DecodeValueError)
+        } else {
+            Ok(Value::new(bits.get() as i16 + Self::MIN.get()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn new_accepts_values_within_bounds(#[strategy(Value::MIN.get()..=Value::MAX.get())] v: i16) {
+        assert_eq!(Value::new(v), Value(v));
+    }
+
+    #[proptest]
+    #[should_panic]
+    fn new_panics_if_value_greater_than_max(#[strategy(Value::MAX.get() + 1..)] v: i16) {
+        Value::new(v);
+    }
+
+    #[proptest]
+    #[should_panic]
+    fn new_panics_if_value_smaller_than_min(#[strategy(..Value::MIN.get())] v: i16) {
+        Value::new(v);
+    }
+
+    #[proptest]
+    fn saturate_preserves_values_within_bounds(
+        #[strategy(Value::MIN.get()..=Value::MAX.get())] v: i16,
+    ) {
+        assert_eq!(Value::saturate(v), Value(v));
+    }
+
+    #[proptest]
+    fn saturate_caps_if_value_greater_than_max(#[strategy(Value::MAX.get() + 1..)] v: i16) {
+        assert_eq!(Value::saturate(v), Value::MAX);
+    }
+
+    #[proptest]
+    fn saturate_caps_if_value_smaller_than_min(#[strategy(..Value::MIN.get())] v: i16) {
+        assert_eq!(Value::saturate(v), Value::MIN);
+    }
+
+    #[proptest]
+    fn get_returns_raw_value(v: Value) {
+        assert_eq!(v.get(), v.0);
+    }
+
+    #[proptest]
+    fn double_negation_is_idempotent(v: Value) {
+        assert_eq!(-(-v), v);
+    }
+
+    #[proptest]
+    fn addition_is_symmetric(a: Value, b: Value) {
+        assert_eq!(a + b, b + a);
+    }
+
+    #[proptest]
+    fn subtraction_is_antisymmetric(a: Value, b: Value) {
+        assert_eq!(a - b, -(b - a));
+    }
+
+    #[proptest]
+    fn decoding_encoded_value_is_an_identity(v: Value) {
+        assert_eq!(Binary::decode(v.encode()), Ok(v));
+    }
+
+    #[proptest]
+    fn decoding_value_fails_for_invalid_bits() {
+        let b = !<Value as Binary>::Bits::default();
+        assert_eq!(Value::decode(b), Err(DecodeValueError));
+    }
+}

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -1,0 +1,116 @@
+use crate::util::{Binary, Bits};
+use derive_more::{Display, Error};
+use num_traits::{clamp, AsPrimitive};
+use std::convert::Infallible;
+use test_strategy::Arbitrary;
+
+#[derive(Debug, Display, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Arbitrary)]
+#[display(fmt = "{}", _0)]
+pub struct Depth(#[strategy(Self::MIN.get()..Self::MAX.get())] u8);
+
+impl Depth {
+    pub const ZERO: Self = Depth(0);
+    pub const MIN: Self = Self::ZERO;
+
+    #[cfg(not(test))]
+    pub const MAX: Self = Depth(31);
+
+    #[cfg(test)]
+    pub const MAX: Self = Depth(3);
+
+    /// Constructs [`Depth`] from a raw number.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `d` is outside of the bounds.
+    #[inline]
+    pub fn new(d: u8) -> Self {
+        d.try_into().unwrap()
+    }
+
+    /// Returns the raw depth.
+    #[inline]
+    pub fn get(&self) -> u8 {
+        self.0
+    }
+
+    /// Safely constructs [`Depth`] from a raw number through saturation.
+    #[inline]
+    pub fn saturate<T: AsPrimitive<u8> + From<u8> + PartialOrd>(i: T) -> Self {
+        Depth(clamp(i, Self::MIN.get().into(), Self::MAX.get().into()).as_())
+    }
+}
+
+/// The reason why converting [`Depth`] from an integer failed.
+#[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
+#[display(
+    fmt = "expected integer in the range `({}..={})`",
+    Depth::MIN,
+    Depth::MAX
+)]
+pub struct DepthOutOfRange;
+
+impl TryFrom<u8> for Depth {
+    type Error = DepthOutOfRange;
+
+    #[inline]
+    fn try_from(n: u8) -> Result<Self, Self::Error> {
+        if (Self::MIN.get()..=Self::MAX.get()).contains(&n) {
+            Ok(Depth(n))
+        } else {
+            Err(DepthOutOfRange)
+        }
+    }
+}
+
+impl Binary for Depth {
+    type Bits = Bits<u8, 5>;
+    type Error = Infallible;
+
+    fn encode(&self) -> Self::Bits {
+        Bits::new(self.get())
+    }
+
+    fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
+        Ok(Depth::new(bits.get()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn new_accepts_numbers_within_bounds(#[strategy(Depth::MIN.get()..=Depth::MAX.get())] d: u8) {
+        assert_eq!(Depth::new(d), Depth(d));
+    }
+
+    #[proptest]
+    #[should_panic]
+    fn new_panics_if_number_greater_than_max(#[strategy(Depth::MAX.get() + 1..)] d: u8) {
+        Depth::new(d);
+    }
+
+    #[proptest]
+    fn saturate_preserves_numbers_within_bounds(
+        #[strategy(Depth::MIN.get()..=Depth::MAX.get())] n: u8,
+    ) {
+        assert_eq!(Depth::saturate(n), Depth(n));
+    }
+
+    #[proptest]
+    fn saturate_caps_if_numbers_greater_than_max(#[strategy(Depth::MAX.get() + 1..)] n: u8) {
+        assert_eq!(Depth::saturate(n), Depth::MAX);
+    }
+
+    #[proptest]
+    fn get_returns_raw_depth(d: Depth) {
+        assert_eq!(d.get(), d.0);
+    }
+
+    #[proptest]
+    fn decoding_encoded_depth_is_an_identity(d: Depth) {
+        assert_eq!(Binary::decode(d.encode()), Ok(d));
+    }
+}

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -1,15 +1,14 @@
+use super::Depth;
 use crate::{chess::Move, eval::Value, transposition::Transposition};
 use arrayvec::ArrayVec;
-use derive_more::{Deref, DerefMut, Display, IntoIterator};
+use derive_more::{Deref, Display, IntoIterator};
 use proptest::prelude::*;
 use test_strategy::Arbitrary;
 
 /// The [principal variation].
 ///
 /// [principal variation]: https://www.chessprogramming.org/Principal_Variation
-#[derive(
-    Debug, Display, Default, Clone, Eq, PartialEq, Hash, Arbitrary, Deref, DerefMut, IntoIterator,
-)]
+#[derive(Debug, Display, Default, Clone, Eq, PartialEq, Hash, Arbitrary, Deref, IntoIterator)]
 #[display(
     fmt = "{}",
     "self.iter().map(Move::to_string).collect::<ArrayVec<_, N>>().join(\" \")"
@@ -17,16 +16,15 @@ use test_strategy::Arbitrary;
 pub struct Pv<const N: usize> {
     #[strategy(any::<Vec<Move>>().prop_map(|v| v.into_iter().take(N).collect()))]
     #[deref(forward)]
-    #[deref_mut(forward)]
     #[into_iterator(owned, ref, ref_mut)]
     moves: ArrayVec<Move, N>,
-    #[strategy(any::<(u8, Value)>().prop_map(move |i| #moves.first().map(move |_| i)))]
-    info: Option<(u8, Value)>,
+    #[strategy(any::<(Depth, Value)>().prop_map(move |i| #moves.first().map(move |_| i)))]
+    info: Option<(Depth, Value)>,
 }
 
 impl<const N: usize> Pv<N> {
     /// Constructs a new [`Pv`] given depth, score, and sequence of moves.
-    pub fn new<I: IntoIterator<Item = Move>>(depth: u8, score: Value, moves: I) -> Self {
+    pub fn new<I: IntoIterator<Item = Move>>(depth: Depth, score: Value, moves: I) -> Self {
         Self {
             moves: moves.into_iter().take(N).collect(),
             info: Some((depth, score)),
@@ -34,7 +32,7 @@ impl<const N: usize> Pv<N> {
     }
 
     /// The depth of this sequence.
-    pub fn depth(&self) -> Option<u8> {
+    pub fn depth(&self) -> Option<Depth> {
         self.info.map(|(d, _)| d)
     }
 
@@ -72,21 +70,11 @@ impl<const N: usize> Pv<N> {
 /// Create a [`Pv`] from an iterator.
 ///
 /// Truncates the sequence at the N-th [`Transposition`].
-///
-/// # Panics
-/// Panics if the sequence is not strictly decreasing by depth.
 impl<const N: usize> FromIterator<Transposition> for Pv<N> {
     fn from_iter<I: IntoIterator<Item = Transposition>>(tts: I) -> Self {
-        let mut tts = tts.into_iter().filter(|t| t.depth() > 0).peekable();
+        let mut tts = tts.into_iter().filter(|t| t.depth().get() > 0).peekable();
         let info = tts.peek().map(|t| (t.depth(), t.score()));
-
-        let mut depth = u8::MAX;
-        let moves = ArrayVec::from_iter(tts.take(N).map(|t| {
-            assert!(t.depth() <= depth);
-            depth = t.depth() - 1;
-            t.best()
-        }));
-
+        let moves = ArrayVec::from_iter(tts.take(N).map(|t| t.best()));
         Pv { info, moves }
     }
 }
@@ -101,11 +89,11 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn new_truncates_moves(d: u8, s: Value, #[any(size_range(10..20).lift())] m: Vec<Move>) {
+    fn new_truncates_moves(d: Depth, s: Value, #[any(size_range(4..8).lift())] ms: Vec<Move>) {
         assert_eq!(
-            Pv::<10>::new(d, s, m.clone()),
+            Pv::<4>::new(d, s, ms.clone()),
             Pv {
-                moves: m[..10].iter().copied().collect(),
+                moves: ms[..4].iter().copied().collect(),
                 info: Some((d, s)),
             }
         );
@@ -115,8 +103,8 @@ mod tests {
     fn len_returns_number_of_moves_in_the_sequence(tt: Table, pos: Position) {
         assert_eq!(tt.iter(&pos).collect::<Pv<0>>().len(), 0);
         assert_eq!(
-            tt.iter(&pos).collect::<Pv<10>>().len(),
-            tt.iter(&pos).filter(|t| t.depth() > 0).count()
+            tt.iter(&pos).collect::<Pv<4>>().len(),
+            tt.iter(&pos).filter(|t| t.depth() > Depth::ZERO).count()
         );
     }
 
@@ -124,8 +112,8 @@ mod tests {
     fn is_empty_returns_whether_there_are_no_moves_in_the_sequence(tt: Table, pos: Position) {
         assert!(tt.iter(&pos).collect::<Pv<0>>().is_empty());
         assert_eq!(
-            tt.iter(&pos).collect::<Pv<10>>().is_empty(),
-            tt.iter(&pos).filter(|t| t.depth() > 0).count() == 0
+            tt.iter(&pos).collect::<Pv<4>>().is_empty(),
+            tt.iter(&pos).filter(|t| t.depth() > Depth::ZERO).count() == 0
         );
     }
 
@@ -136,7 +124,8 @@ mod tests {
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)]
         pos: Position,
         s: Value,
-        #[strategy(1u8..=Transposition::MAX_DEPTH)] d: u8,
+        d: Depth,
+        #[filter(#e < #d)] e: Depth,
         selector: Selector,
     ) {
         let (m, next) = selector.select(pos.moves(MoveKind::ANY));
@@ -148,7 +137,7 @@ mod tests {
         tt.unset(pos.zobrist());
         tt.set(pos.zobrist(), t);
 
-        let u = Transposition::lower(d - 1, s, n);
+        let u = Transposition::lower(e, s, n);
         tt.unset(next.zobrist());
         tt.set(next.zobrist(), u);
 
@@ -166,7 +155,7 @@ mod tests {
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)]
         pos: Position,
         s: Value,
-        #[strategy(1..=Transposition::MAX_DEPTH)] a: u8,
+        #[filter(#d > Depth::ZERO)] d: Depth,
         selector: Selector,
     ) {
         let (m, next) = selector.select(pos.moves(MoveKind::ANY));
@@ -174,11 +163,11 @@ mod tests {
 
         let (n, _) = selector.select(next.moves(MoveKind::ANY));
 
-        let t = Transposition::lower(a, s, m);
+        let t = Transposition::lower(d, s, m);
         tt.unset(pos.zobrist());
         tt.set(pos.zobrist(), t);
 
-        let u = Transposition::lower(0, s, n);
+        let u = Transposition::lower(Depth::ZERO, s, n);
         tt.unset(next.zobrist());
         tt.set(next.zobrist(), u);
 
@@ -186,10 +175,7 @@ mod tests {
         prop_assume!(tt.get(next.zobrist()) == Some(u));
 
         assert!(tt.iter(&pos).count() > 1);
-        assert_eq!(
-            &tt.iter(&pos).collect::<Pv<10>>()[..],
-            [t.best()].as_slice()
-        );
+        assert_eq!([t.best()].as_slice(), &*tt.iter(&pos).collect::<Pv<4>>());
     }
 
     #[proptest]
@@ -199,7 +185,7 @@ mod tests {
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)]
         pos: Position,
         s: Value,
-        #[strategy(1..Transposition::MAX_DEPTH)] d: u8,
+        #[filter(#d > Depth::ZERO)] d: Depth,
         selector: Selector,
     ) {
         let (m, _) = selector.select(pos.moves(MoveKind::ANY));
@@ -225,25 +211,13 @@ mod tests {
     ) {
         let (m, _) = selector.select(pos.moves(MoveKind::ANY));
 
-        let t = Transposition::lower(0, s, m);
+        let t = Transposition::lower(Depth::ZERO, s, m);
         tt.unset(pos.zobrist());
         tt.set(pos.zobrist(), t);
 
-        let pv: Pv<10> = tt.iter(&pos).collect();
+        let pv: Pv<4> = tt.iter(&pos).collect();
         assert_eq!(pv.depth(), None);
         assert_eq!(pv.score(), None);
         assert_eq!(&pv[..], [].as_slice())
-    }
-
-    #[proptest]
-    #[should_panic]
-    fn panics_if_sequence_is_not_strictly_decreasing_by_depth(
-        #[by_ref]
-        #[any(size_range(2..=10).lift())]
-        mut tts: Vec<Transposition>,
-    ) {
-        tts.sort_by_key(|t| !t.depth());
-        tts.rotate_left(1);
-        let _: Pv<10> = tts.iter().copied().collect();
     }
 }

--- a/lib/transposition/iter.rs
+++ b/lib/transposition/iter.rs
@@ -35,7 +35,7 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chess::MoveKind;
+    use crate::{chess::MoveKind, eval::Value};
     use proptest::{prop_assume, sample::Selector};
     use test_strategy::proptest;
 
@@ -48,7 +48,7 @@ mod tests {
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)]
         pos: Position,
         #[strategy(0..=Transposition::MAX_DEPTH)] d: u8,
-        s: i16,
+        s: Value,
         selector: Selector,
     ) {
         let (m, next) = selector.select(pos.moves(MoveKind::ANY));
@@ -56,11 +56,11 @@ mod tests {
 
         let (n, _) = selector.select(next.moves(MoveKind::ANY));
 
-        let t = Transposition::lower(s, d, m);
+        let t = Transposition::lower(d, s, m);
         tt.unset(pos.zobrist());
         tt.set(pos.zobrist(), t);
 
-        let u = Transposition::lower(s.saturating_neg(), d, n);
+        let u = Transposition::lower(d, -s, n);
         tt.unset(next.zobrist());
         tt.set(next.zobrist(), u);
 

--- a/lib/transposition/iter.rs
+++ b/lib/transposition/iter.rs
@@ -25,8 +25,8 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let d = self.depth?;
         let key = self.pos.zobrist();
-        let t = self.tt.get(key).filter(|t| t.depth() <= d)?;
-        self.depth = t.depth().checked_sub(1);
+        let t = self.tt.get(key).filter(|t| t.depth().get() <= d)?;
+        self.depth = t.depth().get().checked_sub(1);
         self.pos.make(t.best()).ok()?;
         Some(t)
     }
@@ -35,7 +35,7 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chess::MoveKind, eval::Value};
+    use crate::{chess::MoveKind, eval::Value, search::Depth};
     use proptest::{prop_assume, sample::Selector};
     use test_strategy::proptest;
 
@@ -47,7 +47,7 @@ mod tests {
         #[by_ref]
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)]
         pos: Position,
-        #[strategy(0..=Transposition::MAX_DEPTH)] d: u8,
+        d: Depth,
         s: Value,
         selector: Selector,
     ) {


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1800:

```
games: 8000, wins: 4942, losses: 2941, draws: 117, ΔELO: [+82.26, +98.16]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     34     29     44     44     45     43     35     26     27     55     27     47     37     51     29    573
   Score    593    529    650    673    718    876    614    539    505    806    592    755    623    747    678   9898
Score(%)   59.3   52.9   65.0   67.3   71.8   87.6   61.4   53.9   50.5   80.6   59.2   75.5   62.3   74.7   67.8   66.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.6%, "Re-Capturing"
2. STS 10, 80.6%, "Simplification"
3. STS 12, 75.5%, "Center Control"
4. STS 14, 74.7%, "Queens and Rooks to the 7th rank"
5. STS 05, 71.8%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 09, 50.5%, "Advancement of a/b/c Pawns"
2. STS 02, 52.9%, "Open Files and Diagonals"
3. STS 08, 53.9%, "Advancement of f/g/h Pawns"
4. STS 11, 59.2%, "Activity of the King"
5. STS 01, 59.3%, "Undermining"
```