### PR TITLE
Introduce struct Report for search results

### DIFF
--- a/benches/ttd.rs
+++ b/benches/ttd.rs
@@ -25,7 +25,7 @@ fn ttd(c: &mut Criterion, fens: &[&str]) {
                     positions.next().unwrap(),
                 )
             },
-            |(s, pos)| s.search::<0>(pos, Depth::new(8).into()),
+            |(s, pos)| s.search(pos, Depth::new(8).into()),
             BatchSize::SmallInput,
         );
     });

--- a/benches/ttm.rs
+++ b/benches/ttm.rs
@@ -32,8 +32,10 @@ fn ttm(c: &mut Criterion, name: &str, edps: &[(&str, &str)]) {
                 |(s, (pos, m))| {
                     let timer = Instant::now();
                     for d in 1..=Depth::upper().get() {
-                        let pv = s.search::<1>(pos, Limits::Depth(Depth::new(d)));
-                        if pv.first() == Some(m) || timer.elapsed() >= Duration::from_millis(80) {
+                        let report = s.search(pos, Limits::Depth(Depth::new(d)));
+                        if report.pv().first() == Some(m)
+                            || timer.elapsed() >= Duration::from_millis(80)
+                        {
                             break;
                         }
                     }

--- a/bin/applet/analyze.rs
+++ b/bin/applet/analyze.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Error as Anyhow};
 use clap::Parser;
 use futures_util::TryStreamExt;
 use lib::chess::{Color, Fen};
+use lib::search::Limits;
 use tracing::{info, instrument};
 
 /// Analyzes a position.
@@ -13,6 +14,10 @@ pub struct Analyze {
     #[clap(short, long, default_value_t)]
     engine: EngineConfig,
 
+    /// Search limits to use.
+    #[clap(short, long, default_value_t)]
+    limits: Limits,
+
     /// The position to analyze in FEN notation.
     fen: Fen,
 }
@@ -22,7 +27,7 @@ impl Analyze {
     pub async fn execute(self) -> Result<(), Anyhow> {
         let pos = self.fen.try_into()?;
         let mut engine = self.engine.build()?;
-        let mut analysis = engine.analyze::<256>(&pos);
+        let mut analysis = engine.analyze::<256>(&pos, self.limits);
 
         while let Some(pv) = analysis.try_next().await? {
             let (d, s) =

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -31,6 +31,24 @@ impl Build for EngineConfig {
 }
 
 #[cfg(test)]
+mockall::mock! {
+    #[derive(Debug)]
+    pub Builder<T> {}
+    impl<T> Build for Builder<T> {
+        type Output = T;
+        type Error = String;
+        fn build(self) -> Result<T, String>;
+    }
+}
+
+#[cfg(test)]
+impl<T> std::fmt::Display for MockBuilder<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self, f)
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::engine::UciOptions;

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -20,13 +20,11 @@ impl Build for EngineConfig {
 
     fn build(self) -> Result<Self::Output, Self::Error> {
         match self {
-            EngineConfig::Ai(limits, options) => {
-                Ok(Ai::new(Evaluator::new(), limits, options).into())
-            }
+            EngineConfig::Ai(options) => Ok(Ai::new(Evaluator::new(), options).into()),
 
-            EngineConfig::Uci(path, limits, options) => {
+            EngineConfig::Uci(path, options) => {
                 let io = Process::spawn(&path).map_err(UciError::from)?;
-                Ok(Uci::new(io, limits, options).into())
+                Ok(Uci::new(io, options).into())
             }
         }
     }
@@ -36,18 +34,18 @@ impl Build for EngineConfig {
 mod tests {
     use super::*;
     use crate::engine::UciOptions;
-    use lib::search::{Limits, Options};
+    use lib::search::Options;
     use test_strategy::proptest;
 
     #[proptest]
-    fn ai_can_be_configured_at_runtime(l: Limits, o: Options) {
-        assert!(matches!(EngineConfig::Ai(l, o).build(), Ok(Engine::Ai(_))));
+    fn ai_can_be_configured_at_runtime(o: Options) {
+        assert!(matches!(EngineConfig::Ai(o).build(), Ok(Engine::Ai(_))));
     }
 
     #[proptest]
-    fn uci_can_be_configured_at_runtime(s: String, l: Limits, o: UciOptions) {
+    fn uci_can_be_configured_at_runtime(s: String, o: UciOptions) {
         assert!(matches!(
-            EngineConfig::Uci(s, l, o).build(),
+            EngineConfig::Uci(s, o).build(),
             Ok(Engine::Uci(_))
         ));
     }

--- a/bin/engine.rs
+++ b/bin/engine.rs
@@ -1,10 +1,9 @@
-use crate::io::Process;
-use crate::player::Player;
+use crate::{io::Process, player::Player};
 use async_stream::stream;
 use derive_more::{DebugCustom, Display, Error, From};
 use futures_util::{future::BoxFuture, stream::BoxStream};
 use lib::chess::{Move, Position};
-use lib::search::{Limits, Options, Pv};
+use lib::search::{Limits, Options, Report};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use test_strategy::Arbitrary;
@@ -82,11 +81,11 @@ impl Player for Engine {
         })
     }
 
-    fn analyze<'a, 'b, 'c, const N: usize>(
+    fn analyze<'a, 'b, 'c>(
         &'a mut self,
         pos: &'b Position,
         limits: Limits,
-    ) -> BoxStream<'c, Result<Pv<N>, Self::Error>>
+    ) -> BoxStream<'c, Result<Report, Self::Error>>
     where
         'a: 'c,
         'b: 'c,

--- a/bin/player.rs
+++ b/bin/player.rs
@@ -1,8 +1,9 @@
 use futures_util::{future::BoxFuture, stream::BoxStream};
 use lib::chess::{Move, Position};
-use lib::search::{Limits, Pv};
+use lib::search::{Limits, Report};
 
 /// Trait for types that know how to analyze chess [`Position`]s.
+#[cfg_attr(test, mockall::automock(type Error = String;))]
 pub trait Player {
     /// The reason why the [`Player`] was unable to continue.
     type Error;
@@ -18,11 +19,11 @@ pub trait Player {
         'b: 'c;
 
     /// Analyzes a [`Position`].
-    fn analyze<'a, 'b, 'c, const N: usize>(
+    fn analyze<'a, 'b, 'c>(
         &'a mut self,
         pos: &'b Position,
         limits: Limits,
-    ) -> BoxStream<'c, Result<Pv<N>, Self::Error>>
+    ) -> BoxStream<'c, Result<Report, Self::Error>>
     where
         'a: 'c,
         'b: 'c;

--- a/bin/player.rs
+++ b/bin/player.rs
@@ -1,6 +1,6 @@
 use futures_util::{future::BoxFuture, stream::BoxStream};
 use lib::chess::{Move, Position};
-use lib::search::Pv;
+use lib::search::{Limits, Pv};
 
 /// Trait for types that know how to analyze chess [`Position`]s.
 pub trait Player {
@@ -11,6 +11,7 @@ pub trait Player {
     fn play<'a, 'b, 'c>(
         &'a mut self,
         pos: &'b Position,
+        limits: Limits,
     ) -> BoxFuture<'c, Result<Move, Self::Error>>
     where
         'a: 'c,
@@ -20,6 +21,7 @@ pub trait Player {
     fn analyze<'a, 'b, 'c, const N: usize>(
         &'a mut self,
         pos: &'b Position,
+        limits: Limits,
     ) -> BoxStream<'c, Result<Pv<N>, Self::Error>>
     where
         'a: 'c,

--- a/lib/chess/pgn.rs
+++ b/lib/chess/pgn.rs
@@ -1,4 +1,5 @@
 use super::{Color, Outcome, San};
+use proptest::sample::size_range;
 use std::fmt::{self, Display};
 use test_strategy::Arbitrary;
 
@@ -8,6 +9,7 @@ pub struct Pgn {
     pub white: String,
     pub black: String,
     pub outcome: Outcome,
+    #[any(size_range(0..=3).lift())]
     pub moves: Vec<San>,
 }
 
@@ -62,7 +64,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 10)]
+    #[proptest]
     fn prints_simplified_pgn(pgn: Pgn) {
         let mut reader = BufferedReader::new_cursor(pgn.to_string());
         let mut visitor = PgnVisitor::default();

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -76,7 +76,7 @@ pub struct Position(
             }
         }
         chess
-    }).no_shrink())]
+    }))]
     sm::Chess,
 );
 

--- a/lib/eval.rs
+++ b/lib/eval.rs
@@ -10,14 +10,6 @@ pub use end::*;
 pub use mid::*;
 pub use value::*;
 
-/// Trait for types that can evaluate [`Position`]s.
-pub trait Eval {
-    /// Evaluates a [`Position`].
-    ///
-    /// Positive values favor the current side to play.
-    fn eval(&self, item: &Position) -> Value;
-}
-
 /// A tapered evaluator.
 #[derive(Debug, Default, Clone, Arbitrary, Constructor)]
 pub struct Evaluator();
@@ -61,10 +53,11 @@ impl Evaluator {
             Color::Black => s.index() as usize,
         }]
     }
-}
 
-impl Eval for Evaluator {
-    fn eval(&self, pos: &Position) -> Value {
+    /// Evaluates a [`Position`].
+    ///
+    /// Positive values favor the current side to play.
+    pub fn eval(&self, pos: &Position) -> Value {
         let turn = pos.turn();
         let phase = self.phase(pos);
 

--- a/lib/search.rs
+++ b/lib/search.rs
@@ -1,5 +1,5 @@
 use crate::chess::{Move, MoveKind, Piece, Position, Role, Zobrist};
-use crate::eval::{Eval, Evaluator, Value};
+use crate::eval::{Evaluator, Value};
 use crate::transposition::{Table, Transposition};
 use crate::util::{Timeout, Timer};
 use derive_more::{Deref, Neg};

--- a/lib/search/report.rs
+++ b/lib/search/report.rs
@@ -1,0 +1,32 @@
+use super::{Depth, Pv};
+use crate::eval::Value;
+use derive_more::Constructor;
+use test_strategy::Arbitrary;
+
+/// The result of an  .
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Arbitrary, Constructor)]
+pub struct Report {
+    depth: Depth,
+    score: Value,
+    pv: Pv,
+}
+
+impl Report {
+    /// The depth searched.
+    #[inline]
+    pub fn depth(&self) -> Depth {
+        self.depth
+    }
+
+    /// The score from the point of view of the side to move.
+    #[inline]
+    pub fn score(&self) -> Value {
+        self.score
+    }
+
+    /// The best line .
+    #[inline]
+    pub fn pv(&self) -> &Pv {
+        &self.pv
+    }
+}

--- a/lib/transposition/iter.rs
+++ b/lib/transposition/iter.rs
@@ -1,12 +1,12 @@
 use super::{Table, Transposition};
 use crate::chess::Position;
 
-/// An iterator over the sequence of [`Transposition`]s in a transposition [`Table`].
+/// An iterator over a sequence of [`Transposition`]s in a transposition [`Table`].
 #[derive(Debug, Clone)]
 pub struct Iter<'a> {
     tt: &'a Table,
     pos: Position,
-    depth: Option<u8>,
+    depth: u8,
 }
 
 impl<'a> Iter<'a> {
@@ -14,7 +14,7 @@ impl<'a> Iter<'a> {
         Iter {
             tt,
             pos,
-            depth: Some(u8::MAX),
+            depth: u8::MAX,
         }
     }
 }
@@ -23,10 +23,9 @@ impl<'a> Iterator for Iter<'a> {
     type Item = Transposition;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let d = self.depth?;
         let key = self.pos.zobrist();
-        let t = self.tt.get(key).filter(|t| t.depth() <= d)?;
-        self.depth = t.depth().get().checked_sub(1);
+        let t = self.tt.get(key).filter(|t| t.depth() <= self.depth)?;
+        self.depth = t.depth().get().checked_sub(1)?;
         self.pos.make(t.best()).ok()?;
         Some(t)
     }
@@ -45,7 +44,7 @@ mod tests {
         #[filter(#tt.capacity() > 1)]
         tt: Table,
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
-        d: Depth,
+        #[filter(#d > Depth::new(0))] d: Depth,
         s: Value,
         selector: Selector,
     ) {

--- a/lib/transposition/table.rs
+++ b/lib/transposition/table.rs
@@ -1,5 +1,5 @@
 use super::{Iter, OptionalSignedTransposition, Signature, Transposition};
-use crate::chess::{Position, Zobrist};
+use crate::chess::{Move, Position, Zobrist};
 use crate::util::{Binary, Cache};
 use proptest::{collection::*, prelude::*};
 use std::mem::size_of;
@@ -19,8 +19,7 @@ pub struct Table {
         }
 
         cache
-    })
-    .no_shrink())]
+    }))]
     cache: Cache<<OptionalSignedTransposition as Binary>::Bits>,
 }
 
@@ -89,9 +88,14 @@ impl Table {
         self.cache.store(self.index_of(key), None.encode())
     }
 
-    /// An iterator for the principal variation from a starting [`Position`].
-    pub fn iter(&self, pos: &Position) -> Iter<'_> {
+    /// An iterator for a sequence of [`Transposition`]s from a starting [`Position`].
+    pub fn iter(&self, pos: &Position) -> impl Iterator<Item = Transposition> + '_ {
         Iter::new(self, pos.clone())
+    }
+
+    /// An iterator for the principal variation from a starting [`Position`].
+    pub fn pv(&self, pos: &Position) -> impl Iterator<Item = Move> + '_ {
+        self.iter(pos).map(|t| t.best())
     }
 }
 


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 8000, wins: 4880, losses: 3018, draws: 102, ΔELO: [+75.62, +91.42]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     37     30     46     41     47     41     31     21     32     51     28     43     39     46     27    560
   Score    623    550    680    641    729    874    598    509    544    790    574    739    639    707    636   9833
Score(%)   62.3   55.0   68.0   64.1   72.9   87.4   59.8   50.9   54.4   79.0   57.4   73.9   63.9   70.7   63.6   65.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.4%, "Re-Capturing"
2. STS 10, 79.0%, "Simplification"
3. STS 12, 73.9%, "Center Control"
4. STS 05, 72.9%, "Bishop vs Knight"
5. STS 14, 70.7%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 08, 50.9%, "Advancement of f/g/h Pawns"
2. STS 09, 54.4%, "Advancement of a/b/c Pawns"
3. STS 02, 55.0%, "Open Files and Diagonals"
4. STS 11, 57.4%, "Activity of the King"
5. STS 07, 59.8%, "Offer of Simplification"
```