### PR TITLE
Implement mate distance pruning

### DIFF
--- a/bin/engine/ai.rs
+++ b/bin/engine/ai.rs
@@ -99,7 +99,7 @@ impl Player for Ai {
 mod tests {
     use super::*;
     use futures_util::TryStreamExt;
-    use lib::{eval::Value, search::Pv};
+    use lib::search::{Pv, Score};
     use mockall::predicate::eq;
     use proptest::sample::size_range;
     use std::time::Duration;
@@ -123,7 +123,7 @@ mod tests {
 
     #[proptest]
     #[should_panic]
-    fn play_panics_if_there_are_no_legal_moves(l: Limits, pos: Position, d: Depth, s: Value) {
+    fn play_panics_if_there_are_no_legal_moves(l: Limits, pos: Position, d: Depth, s: Score) {
         let rt = runtime::Builder::new_multi_thread().build()?;
 
         let mut strategy = Strategy::new();

--- a/lib/eval/value.rs
+++ b/lib/eval/value.rs
@@ -1,52 +1,13 @@
-use crate::util::{Binary, Bits, Bounds, Saturating};
-use derive_more::{Display, Error};
-use test_strategy::Arbitrary;
+use crate::search::{PlyBounds, ScoreBounds};
+use crate::util::{Bounds, Saturating};
 
 pub struct ValueBounds;
 
 impl Bounds for ValueBounds {
     type Integer = i16;
     const LOWER: Self::Integer = -Self::UPPER;
-    const UPPER: Self::Integer = 4095;
+    const UPPER: Self::Integer = ScoreBounds::UPPER - PlyBounds::UPPER as i16 - 1;
 }
 
+/// A [`Position`]'s static evaluation.
 pub type Value = Saturating<ValueBounds>;
-
-/// The reason why decoding [`Value`] from binary failed.
-#[derive(Debug, Display, Clone, Eq, PartialEq, Arbitrary, Error)]
-#[display(fmt = "not a valid Value")]
-pub struct DecodeValueError;
-
-impl Binary for Value {
-    type Bits = Bits<u16, 13>;
-    type Error = DecodeValueError;
-
-    fn encode(&self) -> Self::Bits {
-        Bits::new((self.get() - ValueBounds::LOWER) as _)
-    }
-
-    fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
-        if bits == !Bits::default() {
-            Err(DecodeValueError)
-        } else {
-            Ok(Value::new(bits.get() as i16 + ValueBounds::LOWER))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_strategy::proptest;
-
-    #[proptest]
-    fn decoding_encoded_value_is_an_identity(v: Value) {
-        assert_eq!(Binary::decode(v.encode()), Ok(v));
-    }
-
-    #[proptest]
-    fn decoding_value_fails_for_invalid_bits() {
-        let b = !<Value as Binary>::Bits::default();
-        assert_eq!(Value::decode(b), Err(DecodeValueError));
-    }
-}

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -1,5 +1,5 @@
 use crate::util::{Binary, Bits, Bounds, Saturating};
-use std::convert::Infallible;
+use std::{convert::Infallible, fmt};
 
 pub struct DepthBounds;
 
@@ -14,6 +14,7 @@ impl Bounds for DepthBounds {
     const UPPER: Self::Integer = 3;
 }
 
+/// The search depth.
 pub type Depth = Saturating<DepthBounds>;
 
 impl Binary for Depth {
@@ -26,6 +27,12 @@ impl Binary for Depth {
 
     fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
         Ok(Depth::new(bits.get()))
+    }
+}
+
+impl fmt::Display for Depth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get())
     }
 }
 

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -1,16 +1,17 @@
 use crate::util::{Bounds, Saturating};
 
-pub struct DraftBounds;
+pub struct PlyBounds;
 
-impl Bounds for DraftBounds {
+impl Bounds for PlyBounds {
     type Integer = i8;
     const LOWER: Self::Integer = -Self::UPPER;
 
     #[cfg(not(test))]
-    const UPPER: Self::Integer = 31;
+    const UPPER: Self::Integer = 127;
 
     #[cfg(test)]
     const UPPER: Self::Integer = 3;
 }
 
-pub type Draft = Saturating<DraftBounds>;
+/// The number of half-moves played.
+pub type Ply = Saturating<PlyBounds>;

--- a/lib/search/report.rs
+++ b/lib/search/report.rs
@@ -1,13 +1,17 @@
-use super::{Depth, Pv};
-use crate::eval::Value;
+use super::{Depth, Pv, Score};
 use derive_more::Constructor;
 use test_strategy::Arbitrary;
 
-/// The result of an  .
+/// The search result.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Arbitrary, Constructor)]
 pub struct Report {
     depth: Depth,
-    score: Value,
+    #[map(|s: Score| match s.mate() {
+        Some(p) if p > 0 => Score::upper().normalize(p / 2 * 2 + 1),
+        Some(p) => -Score::upper().normalize(p / 2 * 2),
+        None => s
+    })]
+    score: Score,
     pv: Pv,
 }
 
@@ -20,7 +24,7 @@ impl Report {
 
     /// The score from the point of view of the side to move.
     #[inline]
-    pub fn score(&self) -> Value {
+    pub fn score(&self) -> Score {
         self.score
     }
 

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -1,0 +1,113 @@
+use super::Ply;
+use crate::util::{Binary, Bits, Bounds, Saturating};
+use derive_more::{Display, Error};
+use std::fmt;
+use test_strategy::Arbitrary;
+
+pub struct ScoreBounds;
+
+impl Bounds for ScoreBounds {
+    type Integer = i16;
+    const LOWER: Self::Integer = -Self::UPPER;
+    const UPPER: Self::Integer = 4095;
+}
+
+/// The minimax score.
+pub type Score = Saturating<ScoreBounds>;
+
+impl Score {
+    /// Returns number of plies to mate, if one is in the horizon.
+    ///
+    /// Negative number of plies means the opponent is mating.
+    pub fn mate(&self) -> Option<Ply> {
+        if *self <= Score::lower() - Ply::lower() {
+            Some((Score::lower() - *self).cast())
+        } else if *self >= Score::upper() - Ply::upper() {
+            Some((Score::upper() - *self).cast())
+        } else {
+            None
+        }
+    }
+
+    /// Normalizes mate scores relative to `ply`.
+    #[inline]
+    pub fn normalize(&self, ply: Ply) -> Self {
+        if *self <= Score::lower() - Ply::lower() {
+            (*self + ply).min(Score::lower() - Ply::lower())
+        } else if *self >= Score::upper() - Ply::upper() {
+            (*self - ply).max(Score::upper() - Ply::upper())
+        } else {
+            *self
+        }
+    }
+}
+
+/// The reason why decoding [`Score`] from binary failed.
+#[derive(Debug, Display, Clone, Eq, PartialEq, Arbitrary, Error)]
+#[display(fmt = "not a valid score")]
+pub struct DecodeScoreError;
+
+impl Binary for Score {
+    type Bits = Bits<u16, 13>;
+    type Error = DecodeScoreError;
+
+    fn encode(&self) -> Self::Bits {
+        Bits::new((self.get() - ScoreBounds::LOWER) as _)
+    }
+
+    fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
+        if bits != !Bits::default() {
+            Ok(Self::lower() + bits.get())
+        } else {
+            Err(DecodeScoreError)
+        }
+    }
+}
+
+impl fmt::Display for Score {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.mate() {
+            Some(p) if p > 0 => write!(f, "{:+}#{}", self.get(), (p.get() + 1) / 2),
+            Some(p) => write!(f, "{:+}#{}", self.get(), (1 - p.get()) / 2),
+            None => write!(f, "{:+}", self.get()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::Value;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn normalize_ignores_non_mate_scores(v: Value, p: Ply) {
+        let s: Score = v.cast();
+        assert_eq!(s.normalize(p), s);
+    }
+
+    #[proptest]
+    fn normalize_preserves_mate_score(s: Score, p: Ply) {
+        assert_eq!(s.normalize(p).mate().is_some(), s.mate().is_some());
+    }
+
+    #[proptest]
+    fn mate_returns_plies_to_mate(p: Ply) {
+        if p > 0 {
+            assert_eq!(Score::upper().normalize(p).mate(), Some(p));
+        } else {
+            assert_eq!(Score::lower().normalize(-p).mate(), Some(p));
+        }
+    }
+
+    #[proptest]
+    fn decoding_encoded_score_is_an_identity(s: Score) {
+        assert_eq!(Binary::decode(s.encode()), Ok(s));
+    }
+
+    #[proptest]
+    fn decoding_value_fails_for_invalid_bits() {
+        let b = !<Score as Binary>::Bits::default();
+        assert_eq!(Score::decode(b), Err(DecodeScoreError));
+    }
+}

--- a/lib/transposition/iter.rs
+++ b/lib/transposition/iter.rs
@@ -34,7 +34,8 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chess::MoveKind, eval::Value, search::Depth};
+    use crate::chess::MoveKind;
+    use crate::search::{Depth, Score};
     use proptest::{prop_assume, sample::Selector};
     use test_strategy::proptest;
 
@@ -45,7 +46,7 @@ mod tests {
         tt: Table,
         #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
         #[filter(#d > Depth::new(0))] d: Depth,
-        s: Value,
+        s: Score,
         selector: Selector,
     ) {
         let (m, next) = selector.select(pos.moves(MoveKind::ANY));

--- a/lib/util/saturating.rs
+++ b/lib/util/saturating.rs
@@ -9,10 +9,9 @@ use std::{cmp::Ordering, marker::PhantomData};
 use test_strategy::Arbitrary;
 
 /// A saturating bounded integer.
-#[derive(DebugCustom, Display, Arbitrary, Serialize, Deserialize)]
+#[derive(DebugCustom, Arbitrary, Serialize, Deserialize)]
 #[arbitrary(bound(RangeInclusive<T::Integer>: Strategy<Value = T::Integer>))]
 #[debug(fmt = "Saturating({_0:?})")]
-#[display(fmt = "{_0}")]
 #[serde(into = "i64", try_from = "i64")]
 pub struct Saturating<T: Bounds>(#[strategy(T::LOWER..=T::UPPER)] T::Integer);
 
@@ -341,18 +340,13 @@ mod tests {
     }
 
     #[proptest]
-    fn display_is_transparent(s: Saturating<AsymmetricBounds>) {
-        assert_eq!(s.to_string(), s.get().to_string());
-    }
-
-    #[proptest]
     fn serialization_is_transparent(s: Saturating<AsymmetricBounds>) {
         assert_eq!(ron::ser::to_string(&s), ron::ser::to_string(&s.get()));
     }
 
     #[proptest]
     fn deserializing_succeeds_if_within_bounds(s: Saturating<AsymmetricBounds>) {
-        assert_eq!(ron::de::from_str(&s.to_string()), Ok(s));
+        assert_eq!(ron::de::from_str(&s.get().to_string()), Ok(s));
     }
 
     #[proptest]


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 7910, wins: 4836, losses: 2996, draws: 78, ΔELO: [+75.29, +91.15]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:37s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     38     26     46     48     48     39     32     21     33     53     28     47     41     48     25    573
   Score    597    517    681    688    733    868    607    482    553    799    593    769    622    717    664   9890
Score(%)   59.7   51.7   68.1   68.8   73.3   86.8   60.7   48.2   55.3   79.9   59.3   76.9   62.2   71.7   66.4   65.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 86.8%, "Re-Capturing"
2. STS 10, 79.9%, "Simplification"
3. STS 12, 76.9%, "Center Control"
4. STS 05, 73.3%, "Bishop vs Knight"
5. STS 14, 71.7%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 08, 48.2%, "Advancement of f/g/h Pawns"
2. STS 02, 51.7%, "Open Files and Diagonals"
3. STS 09, 55.3%, "Advancement of a/b/c Pawns"
4. STS 11, 59.3%, "Activity of the King"
5. STS 01, 59.7%, "Undermining"
```

## Analysis

```
cargo run --release -- analyze -l 'time("10000ms")' '8/1kp2Q2/1n1p4/3P4/8/8/P1K2PPP/3Rr3 w - - 0 84'
    Finished release [optimized] target(s) in 0.08s
     Running `target/release/cli analyze -l 'time("10000ms")' '8/1kp2Q2/1n1p4/3P4/8/8/P1K2PPP/3Rr3 w - - 0 84'`
  2023-05-29T10:17:50.017209Z  INFO cli::applet::analyze: depth: 1, score: +1690, pv: d1e1
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.017345Z  INFO cli::applet::analyze: depth: 2, score: +961, pv: f7f6 b6c4
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.017523Z  INFO cli::applet::analyze: depth: 3, score: +1503, pv: d1e1 b6c4 e1e8
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.018128Z  INFO cli::applet::analyze: depth: 4, score: +1506, pv: d1e1 b7c8 f7e8 c8b7
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.018884Z  INFO cli::applet::analyze: depth: 5, score: +1551, pv: d1e1 b6c4 e1e7 c4a3 c2d3
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.020477Z  INFO cli::applet::analyze: depth: 6, score: +1551, pv: d1e1 b6c4 e1b1 c4b6 b1e1
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.023254Z  INFO cli::applet::analyze: depth: 7, score: +1551, pv: d1e1 b6c4 e1b1 c4b6 b1e1
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.053070Z  INFO cli::applet::analyze: depth: 8, score: +1573, pv: d1e1 b6c8 c2d3 c8b6 e1e7 b6a8 h2h4
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.089839Z  INFO cli::applet::analyze: depth: 9, score: +1574, pv: d1e1 b6a8 e1e7 b7a6 f7e6 a6b7 e7d7 a8b6 h2h4
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.134693Z  INFO cli::applet::analyze: depth: 10, score: +1593, pv: d1e1 b6c4 c2c3 c4b6 e1e7 b6a8 c3c2
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.217754Z  INFO cli::applet::analyze: depth: 11, score: +1649, pv: d1e1 b6c4 f7e8 c4b6 e8c6 b7a6 c6c7
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.301647Z  INFO cli::applet::analyze: depth: 12, score: +1725, pv: d1e1 b6a4 f7e8 c7c6 d5c6 b7b6 e1e7 b6c5 c6c7 a4b6
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.361698Z  INFO cli::applet::analyze: depth: 13, score: +1761, pv: d1e1 b6a4 f7e8 a4b6 e8c6 b7b8 e1e8 b8a7 c6c7 a7a6 c7d6
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.611486Z  INFO cli::applet::analyze: depth: 14, score: +1883, pv: d1e1 b7b8 f7e8 b8a7 e8c6 b6d5 c6d5 c7c6 d5d6 a7a6
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.725464Z  INFO cli::applet::analyze: depth: 15, score: +1887, pv: d1e1 b6a8 f7e8 b7a7 e8d7 a7a6 e1b1 a6a5 b1b8 a5a6 b8a8
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:50.990677Z  INFO cli::applet::analyze: depth: 16, score: +1935, pv: d1e1 b6a8 f7e8 b7a7 e8d7 a7b6 d7c6 b6a5 c6a8 a5b5
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:51.362404Z  INFO cli::applet::analyze: depth: 17, score: +2049, pv: d1e1 b6c8 f7e8 c7c6 d5c6 b7b6 e8c8 b6c5 c6c7 c5d5 e1e8 d5c6 c2d3 c6b6 c8d7 b6a7
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:51.542413Z  INFO cli::applet::analyze: depth: 18, score: +2100, pv: d1e1 b6c8 f7e8 c7c6 d5c6 b7b8 e1e6 b8c7 e8d7 c7b6 d7c8 b6c5 c6c7 c5b4 e6d6 b4b5
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:51.969562Z  INFO cli::applet::analyze: depth: 19, score: +2264, pv: d1e1 b6c8 f7e8 c7c5 d5c6 b7b8 e1e6 d6d5 e8f7 c8b6 c6c7 b8b7 e6b6 b7b6 c7c8q d5d4
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:52.310347Z  INFO cli::applet::analyze: depth: 20, score: +2323, pv: d1e1 b6c8 f7e8 c7c5 d5c6 b7b8 e1e6 d6d5 e8f7 c8b6 c6c7 b8a7 c7c8r a7a6 c8b8 a6b5
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:17:57.325203Z  INFO cli::applet::analyze: depth: 21, score: +4080#8, pv: d1e1 b6c8 e1b1 c8b6 f7c7 b7c7 b1b6 c7b6 c2d3 b6c5 d3e4 c5c4 e4f5 c4d5 f5f6 d5d4
    at bin/applet/analyze.rs:33 on main

  2023-05-29T10:18:00.017135Z  INFO cli::applet::analyze: depth: 22, score: +4082#7, pv: d1e1 b6c8 f7d7 b7b8 e1e8 b8a7 d7c7 a7a6 e8c8 a6b5 c8b8 b5a4 c7a7
    at bin/applet/analyze.rs:33 on main
```