### PR TITLE
Prune moves during quiescence if see < alpha

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -281,6 +281,11 @@ impl Searcher {
 
         let mut moves: Vec<_> = self.moves(pos, kind).collect();
 
+        #[cfg(not(test))]
+        if draft <= Draft::new(0) {
+            moves.retain(|(_, _, value)| *value >= alpha)
+        }
+
         moves.sort_unstable_by_key(|&(m, _, value)| {
             if Some(m) == transposition.map(|t| t.best()) {
                 Value::upper()


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 1000, wins: 607, losses: 373, draws: 20, ΔELO: [+62.45, +107.43]
```
