### PR TITLE
Fix ELO regression introduced with #436

### DIFF
--- a/lib/util/saturating.rs
+++ b/lib/util/saturating.rs
@@ -119,10 +119,10 @@ where
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>> Eq for Saturating<T, X> {}
+impl<T: PrimInt, X: Bounds<T>> Eq for Saturating<T, X> {}
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
-    PartialEq<Saturating<U, Y>> for Saturating<T, X>
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt, Y: Bounds<U>> PartialEq<Saturating<U, Y>>
+    for Saturating<T, X>
 {
     #[inline]
     fn eq(&self, other: &Saturating<U, Y>) -> bool {
@@ -130,24 +130,22 @@ impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>> PartialEq<U>
-    for Saturating<T, X>
-{
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt> PartialEq<U> for Saturating<T, X> {
     #[inline]
     fn eq(&self, &other: &U) -> bool {
-        i64::eq(&self.get().into(), &other.into())
+        i64::eq(&self.get().to_i64().unwrap(), &other.to_i64().unwrap())
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>> Ord for Saturating<T, X> {
+impl<T: PrimInt, X: Bounds<T>> Ord for Saturating<T, X> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.get().cmp(&other.get())
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
-    PartialOrd<Saturating<U, Y>> for Saturating<T, X>
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt, Y: Bounds<U>> PartialOrd<Saturating<U, Y>>
+    for Saturating<T, X>
 {
     #[inline]
     fn partial_cmp(&self, other: &Saturating<U, Y>) -> Option<Ordering> {
@@ -155,26 +153,24 @@ impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>> PartialOrd<U>
-    for Saturating<T, X>
-{
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt> PartialOrd<U> for Saturating<T, X> {
     #[inline]
     fn partial_cmp(&self, &other: &U) -> Option<Ordering> {
-        i64::partial_cmp(&self.get().into(), &other.into())
+        i64::partial_cmp(&self.get().to_i64().unwrap(), &other.to_i64().unwrap())
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>> Neg for Saturating<T, X> {
+impl<T: PrimInt, X: Bounds<T>> Neg for Saturating<T, X> {
     type Output = Self;
 
     #[inline]
     fn neg(self) -> Self::Output {
-        Saturating::saturate(i64::saturating_neg(self.get().into()))
+        Saturating::saturate(i64::saturating_neg(self.get().to_i64().unwrap()))
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
-    Add<Saturating<U, Y>> for Saturating<T, X>
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt, Y: Bounds<U>> Add<Saturating<U, Y>>
+    for Saturating<T, X>
 {
     type Output = Self;
 
@@ -184,17 +180,20 @@ impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>> Add<U> for Saturating<T, X> {
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt> Add<U> for Saturating<T, X> {
     type Output = Self;
 
     #[inline]
     fn add(self, rhs: U) -> Self::Output {
-        Saturating::saturate(i64::saturating_add(self.get().into(), rhs.into()))
+        Saturating::saturate(i64::saturating_add(
+            self.get().to_i64().unwrap(),
+            rhs.to_i64().unwrap(),
+        ))
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
-    Sub<Saturating<U, Y>> for Saturating<T, X>
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt, Y: Bounds<U>> Sub<Saturating<U, Y>>
+    for Saturating<T, X>
 {
     type Output = Self;
 
@@ -204,17 +203,20 @@ impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>, Y: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, X: Bounds<T>, U: PrimInt + Into<i64>> Sub<U> for Saturating<T, X> {
+impl<T: PrimInt, X: Bounds<T>, U: PrimInt> Sub<U> for Saturating<T, X> {
     type Output = Self;
 
     #[inline]
     fn sub(self, rhs: U) -> Self::Output {
-        Saturating::saturate(i64::saturating_sub(self.get().into(), rhs.into()))
+        Saturating::saturate(i64::saturating_sub(
+            self.get().to_i64().unwrap(),
+            rhs.to_i64().unwrap(),
+        ))
     }
 }
 
-impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>, C: Bounds<U>>
-    Mul<Saturating<U, C>> for Saturating<T, B>
+impl<T: PrimInt, B: Bounds<T>, U: PrimInt, C: Bounds<U>> Mul<Saturating<U, C>>
+    for Saturating<T, B>
 {
     type Output = Self;
 
@@ -224,17 +226,20 @@ impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>, C: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>> Mul<U> for Saturating<T, B> {
+impl<T: PrimInt, B: Bounds<T>, U: PrimInt> Mul<U> for Saturating<T, B> {
     type Output = Self;
 
     #[inline]
     fn mul(self, rhs: U) -> Self::Output {
-        Saturating::saturate(i64::saturating_mul(self.get().into(), rhs.into()))
+        Saturating::saturate(i64::saturating_mul(
+            self.get().to_i64().unwrap(),
+            rhs.to_i64().unwrap(),
+        ))
     }
 }
 
-impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>, C: Bounds<U>>
-    Div<Saturating<U, C>> for Saturating<T, B>
+impl<T: PrimInt, B: Bounds<T>, U: PrimInt, C: Bounds<U>> Div<Saturating<U, C>>
+    for Saturating<T, B>
 {
     type Output = Self;
 
@@ -244,12 +249,15 @@ impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>, C: Bounds<U>>
     }
 }
 
-impl<T: PrimInt + Into<i64>, B: Bounds<T>, U: PrimInt + Into<i64>> Div<U> for Saturating<T, B> {
+impl<T: PrimInt, B: Bounds<T>, U: PrimInt> Div<U> for Saturating<T, B> {
     type Output = Self;
 
     #[inline]
     fn div(self, rhs: U) -> Self::Output {
-        Saturating::saturate(i64::saturating_div(self.get().into(), rhs.into()))
+        Saturating::saturate(i64::saturating_div(
+            self.get().to_i64().unwrap(),
+            rhs.to_i64().unwrap(),
+        ))
     }
 }
 


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 8000, wins: 5022, losses: 2853, draws: 125, ΔELO: [+90.28, +106.29]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     33     28     44     43     51     40     33     26     28     53     27     46     39     48     24    563
   Score    569    566    660    668    748    872    599    557    522    802    593    741    655    758    654   9964
Score(%)   56.9   56.6   66.0   66.8   74.8   87.2   59.9   55.7   52.2   80.2   59.3   74.1   65.5   75.8   65.4   66.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.2%, "Re-Capturing"
2. STS 10, 80.2%, "Simplification"
3. STS 14, 75.8%, "Queens and Rooks to the 7th rank"
4. STS 05, 74.8%, "Bishop vs Knight"
5. STS 12, 74.1%, "Center Control"

:: Top 5 STS with low result ::
1. STS 09, 52.2%, "Advancement of a/b/c Pawns"
2. STS 08, 55.7%, "Advancement of f/g/h Pawns"
3. STS 02, 56.6%, "Open Files and Diagonals"
4. STS 01, 56.9%, "Undermining"
5. STS 11, 59.3%, "Activity of the King"
```