### PR TITLE
Replace trait Bounds generic by associated type

### DIFF
--- a/lib/eval/value.rs
+++ b/lib/eval/value.rs
@@ -4,12 +4,13 @@ use test_strategy::Arbitrary;
 
 pub struct ValueBounds;
 
-impl Bounds<i16> for ValueBounds {
-    const LOWER: i16 = -Self::UPPER;
-    const UPPER: i16 = 4095;
+impl Bounds for ValueBounds {
+    type Integer = i16;
+    const LOWER: Self::Integer = -Self::UPPER;
+    const UPPER: Self::Integer = 4095;
 }
 
-pub type Value = Saturating<i16, ValueBounds>;
+pub type Value = Saturating<ValueBounds>;
 
 /// The reason why decoding [`Value`] from binary failed.
 #[derive(Debug, Display, Clone, Eq, PartialEq, Arbitrary, Error)]

--- a/lib/search.rs
+++ b/lib/search.rs
@@ -23,7 +23,7 @@ pub use options::*;
 pub use pv::*;
 pub use report::*;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Neg)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, Neg)]
 struct Score(#[deref] Value, Draft);
 
 /// An implementation of [minimax].

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -3,17 +3,18 @@ use std::convert::Infallible;
 
 pub struct DepthBounds;
 
-impl Bounds<u8> for DepthBounds {
-    const LOWER: u8 = 0;
+impl Bounds for DepthBounds {
+    type Integer = u8;
+    const LOWER: Self::Integer = 0;
 
     #[cfg(not(test))]
-    const UPPER: u8 = 31;
+    const UPPER: Self::Integer = 31;
 
     #[cfg(test)]
-    const UPPER: u8 = 3;
+    const UPPER: Self::Integer = 3;
 }
 
-pub type Depth = Saturating<u8, DepthBounds>;
+pub type Depth = Saturating<DepthBounds>;
 
 impl Binary for Depth {
     type Bits = Bits<u8, 5>;

--- a/lib/search/draft.rs
+++ b/lib/search/draft.rs
@@ -2,14 +2,15 @@ use crate::util::{Bounds, Saturating};
 
 pub struct DraftBounds;
 
-impl Bounds<i8> for DraftBounds {
-    const LOWER: i8 = -Self::UPPER;
+impl Bounds for DraftBounds {
+    type Integer = i8;
+    const LOWER: Self::Integer = -Self::UPPER;
 
     #[cfg(not(test))]
-    const UPPER: i8 = 31;
+    const UPPER: Self::Integer = 31;
 
     #[cfg(test)]
-    const UPPER: i8 = 3;
+    const UPPER: Self::Integer = 3;
 }
 
-pub type Draft = Saturating<i8, DraftBounds>;
+pub type Draft = Saturating<DraftBounds>;

--- a/lib/util/bounds.rs
+++ b/lib/util/bounds.rs
@@ -1,8 +1,14 @@
+use num_traits::PrimInt;
+use std::fmt::{Debug, Display};
+
 /// Trait for integer bounds.
-pub trait Bounds<T> {
+pub trait Bounds {
+    /// The equivalent primitive integer
+    type Integer: 'static + PrimInt + Debug + Display + Into<i64>;
+
     /// The lower bound.
-    const LOWER: T;
+    const LOWER: Self::Integer;
 
     /// The upper bound.
-    const UPPER: T;
+    const UPPER: Self::Integer;
 }


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 8000, wins: 4967, losses: 2942, draws: 91, ΔELO: [+83.09, +98.96]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     34     29     41     43     51     43     33     22     34     50     26     47     40     47     28    568
   Score    567    557    623    649    730    871    614    450    548    775    601    749    645    728    649   9756
Score(%)   56.7   55.7   62.3   64.9   73.0   87.1   61.4   45.0   54.8   77.5   60.1   74.9   64.5   72.8   64.9   65.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.1%, "Re-Capturing"
2. STS 10, 77.5%, "Simplification"
3. STS 12, 74.9%, "Center Control"
4. STS 05, 73.0%, "Bishop vs Knight"
5. STS 14, 72.8%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 08, 45.0%, "Advancement of f/g/h Pawns"
2. STS 09, 54.8%, "Advancement of a/b/c Pawns"
3. STS 02, 55.7%, "Open Files and Diagonals"
4. STS 01, 56.7%, "Undermining"
5. STS 11, 60.1%, "Activity of the King"
```