### PR TITLE
Make max PV length configurable once again

### DIFF
--- a/benches/ttd.rs
+++ b/benches/ttd.rs
@@ -25,7 +25,7 @@ fn ttd(c: &mut Criterion, fens: &[&str]) {
                     positions.next().unwrap(),
                 )
             },
-            |(s, pos)| s.search(pos, Depth::new(8).into()),
+            |(s, pos)| s.search::<1>(pos, Depth::new(8).into()),
             BatchSize::SmallInput,
         );
     });

--- a/benches/ttm.rs
+++ b/benches/ttm.rs
@@ -32,7 +32,7 @@ fn ttm(c: &mut Criterion, name: &str, edps: &[(&str, &str)]) {
                 |(s, (pos, m))| {
                     let timer = Instant::now();
                     for d in 1..=DepthBounds::UPPER {
-                        let pv = s.search(pos, Limits::Depth(Depth::new(d)));
+                        let pv = s.search::<1>(pos, Limits::Depth(Depth::new(d)));
                         if pv.first() == Some(m) || timer.elapsed() >= Duration::from_millis(80) {
                             break;
                         }

--- a/bin/engine/ai.rs
+++ b/bin/engine/ai.rs
@@ -16,6 +16,11 @@ trait Searcher {
 
 #[cfg(test)]
 impl MockSearcher {
+    fn search<const N: usize>(&mut self, pos: &Position, limits: Limits) -> Pv<N> {
+        let pv = Searcher::search(self, pos, limits);
+        Pv::new(pv.depth(), pv.score(), pv.iter().copied().collect())
+    }
+
     fn with_options(_: Evaluator, _: Options) -> Self {
         Self::new()
     }
@@ -56,7 +61,7 @@ impl Player for Ai {
         'b: 'c,
     {
         Box::pin(async move {
-            let pv = block_in_place(|| self.strategy.search(pos, limits));
+            let pv: Pv<1> = block_in_place(|| self.strategy.search(pos, limits));
 
             Span::current()
                 .record("depth", display(pv.depth()))

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -1,4 +1,5 @@
-use super::{Depth, Line, Score};
+use super::{Depth, Line, PlyBounds, Score};
+use crate::util::Bounds;
 use derive_more::{Constructor, Deref};
 use test_strategy::Arbitrary;
 
@@ -6,7 +7,7 @@ use test_strategy::Arbitrary;
 ///
 /// [principal variation]: https://www.chessprogramming.org/Principal_Variation
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Arbitrary, Constructor, Deref)]
-pub struct Pv {
+pub struct Pv<const N: usize = { PlyBounds::UPPER as _ }> {
     depth: Depth,
     #[map(|s: Score| match s.mate() {
         Some(p) if p > 0 => Score::upper().normalize(p / 2 * 2 + 1),
@@ -15,10 +16,10 @@ pub struct Pv {
     })]
     score: Score,
     #[deref]
-    line: Line,
+    line: Line<N>,
 }
 
-impl Pv {
+impl<const N: usize> Pv<N> {
     /// The depth searched.
     #[inline]
     pub fn depth(&self) -> Depth {
@@ -33,7 +34,7 @@ impl Pv {
 
     /// The strongest [`Line`].
     #[inline]
-    pub fn line(&self) -> &Line {
+    pub fn line(&self) -> &Line<N> {
         &self.line
     }
 }


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 10000, wins: 6214, losses: 3682, draws: 104, ΔELO: [+83.86, +98.04]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     37     34     48     43     47     39     33     27     25     48     25     47     39     48     30    570
   Score    611    587    669    654    731    876    607    520    509    762    554    725    623    756    670   9854
Score(%)   61.1   58.7   66.9   65.4   73.1   87.6   60.7   52.0   50.9   76.2   55.4   72.5   62.3   75.6   67.0   65.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.6%, "Re-Capturing"
2. STS 10, 76.2%, "Simplification"
3. STS 14, 75.6%, "Queens and Rooks to the 7th rank"
4. STS 05, 73.1%, "Bishop vs Knight"
5. STS 12, 72.5%, "Center Control"

:: Top 5 STS with low result ::
1. STS 09, 50.9%, "Advancement of a/b/c Pawns"
```