### PR TITLE
Generic performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ mockall = { version = "0.11.4", default-features = false }
 pgn-reader = { version = "0.24.0", default-features = false }
 
 [profile.release]
+codegen-units = 1
 lto = "thin"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ pgn-reader = { version = "0.24.0", default-features = false }
 [profile.release]
 codegen-units = 1
 lto = true
+panic = "abort"
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ pgn-reader = { version = "0.24.0", default-features = false }
 
 [profile.release]
 codegen-units = 1
-lto = "thin"
+lto = true
 
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
## Overview 
From https://nnethercote.github.io/perf-book/build-configuration.html.

## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1850

```
games: 8000, wins: 5212, losses: 2700, draws: 88, ΔELO: [+106.22, +122.41]
```

###  Stockfish 15.1 @ UCI_Elo=1900

```
games: 8000, wins: 3175, losses: 4734, draws: 91, ΔELO: [-77.25, -61.61]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     41     31     44     48     52     40     35     26     34     50     23     47     38     47     26    582
   Score    610    573    698    702    786    872    618    542    533    787    575    761    640    733    649  10079
Score(%)   61.0   57.3   69.8   70.2   78.6   87.2   61.8   54.2   53.3   78.7   57.5   76.1   64.0   73.3   64.9   67.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.2%, "Re-Capturing"
2. STS 10, 78.7%, "Simplification"
3. STS 05, 78.6%, "Bishop vs Knight"
4. STS 12, 76.1%, "Center Control"
5. STS 14, 73.3%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 09, 53.3%, "Advancement of a/b/c Pawns"
2. STS 08, 54.2%, "Advancement of f/g/h Pawns"
3. STS 02, 57.3%, "Open Files and Diagonals"
4. STS 11, 57.5%, "Activity of the King"
5. STS 01, 61.0%, "Undermining"
```