### PR TITLE
Implement support for clock based time controls

### DIFF
--- a/bin/analyze.rs
+++ b/bin/analyze.rs
@@ -1,22 +1,12 @@
-use futures_util::{future::BoxFuture, stream::BoxStream};
-use lib::chess::{Move, Position};
+use futures_util::stream::BoxStream;
+use lib::chess::Position;
 use lib::search::{Limits, Pv};
 
 /// Trait for types that know how to analyze chess [`Position`]s.
 #[cfg_attr(test, mockall::automock(type Error = String;))]
-pub trait Player {
-    /// The reason why the [`Player`] was unable to continue.
+pub trait Analyze {
+    /// The reason why the analysis failed.
     type Error;
-
-    /// Finds the best [`Move`].
-    fn play<'a, 'b, 'c>(
-        &'a mut self,
-        pos: &'b Position,
-        limits: Limits,
-    ) -> BoxFuture<'c, Result<Move, Self::Error>>
-    where
-        'a: 'c,
-        'b: 'c;
 
     /// Analyzes a [`Position`].
     fn analyze<'a, 'b, 'c>(

--- a/bin/applet/uci.rs
+++ b/bin/applet/uci.rs
@@ -1,10 +1,8 @@
-use crate::engine::Ai;
 use crate::io::{Io, Pipe};
-use crate::player::Player;
+use crate::{engine::Ai, play::Play};
 use anyhow::{Context, Error as Anyhow};
 use clap::Parser;
 use lib::chess::{Fen, Position};
-use lib::eval::Evaluator;
 use lib::search::{Depth, Limits, Options};
 use std::num::NonZeroUsize;
 use tokio::io::{stdin, stdout};
@@ -42,7 +40,7 @@ impl<T: Io> Server<T> {
     }
 
     fn new_game(&mut self) {
-        self.ai = Ai::new(Evaluator::default(), self.options)
+        self.ai = Ai::new(self.options)
     }
 
     fn set_hash(&mut self, value: &str) -> Result<(), Anyhow> {

--- a/bin/build.rs
+++ b/bin/build.rs
@@ -1,6 +1,5 @@
 use crate::engine::{Ai, Engine, EngineConfig, EngineError, Uci, UciError};
 use crate::io::Process;
-use lib::eval::Evaluator;
 
 /// Trait for types that build other types.
 pub trait Build {
@@ -20,7 +19,7 @@ impl Build for EngineConfig {
 
     fn build(self) -> Result<Self::Output, Self::Error> {
         match self {
-            EngineConfig::Ai(options) => Ok(Ai::new(Evaluator::new(), options).into()),
+            EngineConfig::Ai(options) => Ok(Ai::new(options).into()),
 
             EngineConfig::Uci(path, options) => {
                 let io = Process::spawn(&path).map_err(UciError::from)?;

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,13 +1,14 @@
 use anyhow::Error as Anyhow;
 use clap::Parser;
 
+mod analyze;
 mod applet;
 mod build;
 mod cli;
 mod engine;
 mod game;
 mod io;
-mod player;
+mod play;
 
 #[tokio::main]
 async fn main() -> Result<(), Anyhow> {

--- a/bin/play.rs
+++ b/bin/play.rs
@@ -1,0 +1,14 @@
+use async_trait::async_trait;
+use lib::chess::{Move, Position};
+use lib::search::Limits;
+
+/// Trait for types that know how to play chess.
+#[async_trait]
+#[cfg_attr(test, mockall::automock(type Error = String;))]
+pub trait Play {
+    /// The reason why a move could not be played.
+    type Error;
+
+    /// Finds the best [`Move`].
+    async fn play(&mut self, pos: &Position, limits: Limits) -> Result<Move, Self::Error>;
+}

--- a/lib/chess/outcome.rs
+++ b/lib/chess/outcome.rs
@@ -8,6 +8,9 @@ pub enum Outcome {
     #[display(fmt = "checkmate by the {_0} player")]
     Checkmate(Color),
 
+    #[display(fmt = "{_0} player lost on time")]
+    LossOnTime(Color),
+
     #[display(fmt = "stalemate")]
     Stalemate,
 
@@ -29,13 +32,14 @@ impl Outcome {
     /// Whether the outcome is a decisive and one of the sides has won.
     pub fn is_decisive(&self) -> bool {
         use Outcome::*;
-        matches!(self, Checkmate(_))
+        matches!(self, Checkmate(_) | LossOnTime(_))
     }
 
     /// The winning side, if the outcome is [decisive](`Self::is_decisive`).
     pub fn winner(&self) -> Option<Color> {
         match *self {
             Outcome::Checkmate(c) => Some(c),
+            Outcome::LossOnTime(c) => Some(!c),
             _ => None,
         }
     }
@@ -64,5 +68,10 @@ mod tests {
     #[proptest]
     fn side_that_checkmates_wins(c: Color) {
         assert_eq!(Outcome::Checkmate(c).winner(), Some(c));
+    }
+
+    #[proptest]
+    fn side_that_runs_out_of_time_loses(c: Color) {
+        assert_eq!(Outcome::LossOnTime(c).winner(), Some(!c));
     }
 }

--- a/lib/chess/pgn.rs
+++ b/lib/chess/pgn.rs
@@ -33,6 +33,8 @@ impl Display for Pgn {
             Outcome::DrawBy75MoveRule => write!(f, "{{75-move rule}} 1/2-1/2"),
             Outcome::DrawByInsufficientMaterial => write!(f, "{{insufficient material}} 1/2-1/2"),
             Outcome::Stalemate => write!(f, "{{stalemate}} 1/2-1/2"),
+            Outcome::LossOnTime(Color::Black) => write!(f, "{{loss on time}} 1-0"),
+            Outcome::LossOnTime(Color::White) => write!(f, "{{loss on time}} 0-1"),
             Outcome::Checkmate(Color::Black) => write!(f, "0-1"),
             Outcome::Checkmate(Color::White) => write!(f, "1-0"),
         }

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -9,11 +9,6 @@ use test_strategy::Arbitrary;
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Arbitrary, Constructor, Deref)]
 pub struct Pv<const N: usize = { PlyBounds::UPPER as _ }> {
     depth: Depth,
-    #[map(|s: Score| match s.mate() {
-        Some(p) if p > 0 => Score::upper().normalize(p / 2 * 2 + 1),
-        Some(p) => -Score::upper().normalize(p / 2 * 2),
-        None => s
-    })]
     score: Score,
     #[deref]
     line: Line<N>,


### PR DESCRIPTION
## Test results @ time("100ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1900

```
games: 4500, wins: 1820, losses: 2626, draws: 54, ΔELO: [-74.14, -53.35]
```

## Test results @ clock("3s", "25ms") / 2 threads

###  Stockfish 15.1 @ UCI_Elo=1900

```
games: 8000, wins: 3865, losses: 3973, draws: 162, ΔELO: [-12.48, +2.90]
```

## STS

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     34     35     46     43     52     41     38     26     29     51     25     48     41     50     25    584
   Score    583    601    668    675    746    881    639    498    507    794    589    749    644    738    653   9965
Score(%)   58.3   60.1   66.8   67.5   74.6   88.1   63.9   49.8   50.7   79.4   58.9   74.9   64.4   73.8   65.3   66.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 88.1%, "Re-Capturing"
2. STS 10, 79.4%, "Simplification"
3. STS 12, 74.9%, "Center Control"
4. STS 05, 74.6%, "Bishop vs Knight"
5. STS 14, 73.8%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 08, 49.8%, "Advancement of f/g/h Pawns"
2. STS 09, 50.7%, "Advancement of a/b/c Pawns"
3. STS 01, 58.3%, "Undermining"
4. STS 11, 58.9%, "Activity of the King"
5. STS 02, 60.1%, "Open Files and Diagonals"
```