### PR TITLE
Simplify implementation of SEE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /target
-cobertura.xml
-.vscode
 /proptest-regressions
+/engines
+.vscode
+cobertura.xml
 lcov.info
 perf.data
 perf.data.old

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -155,40 +155,6 @@ impl Position {
             .map(Square::from)
     }
 
-    /// Into where the piece in this [`Square`] can attack.
-    #[inline]
-    pub fn attacks(
-        &self,
-        s: Square,
-    ) -> impl DoubleEndedIterator<Item = Square> + ExactSizeIterator {
-        sm::Position::board(&self.0)
-            .attacks_from(s.into())
-            .into_iter()
-            .map(Square::from)
-    }
-
-    /// From where pieces of this [`Color`] can attack into this [`Square`].
-    #[inline]
-    pub fn attackers(
-        &self,
-        s: Square,
-        c: Color,
-    ) -> impl DoubleEndedIterator<Item = Square> + ExactSizeIterator {
-        let board = sm::Position::board(&self.0);
-        board
-            .attacks_to(s.into(), c.into(), board.occupied())
-            .into_iter()
-            .map(Square::from)
-    }
-
-    /// The [`Square`]s occupied by [`Piece`]s giving check.
-    #[inline]
-    pub fn checkers(&self) -> impl DoubleEndedIterator<Item = Square> + ExactSizeIterator {
-        sm::Position::checkers(&self.0)
-            .into_iter()
-            .map(Square::from)
-    }
-
     /// Whether this position is a [check].
     ///
     /// [check]: https://www.chessprogramming.org/Check
@@ -476,44 +442,6 @@ mod tests {
         for s in pos.by_piece(p) {
             assert_eq!(pos[s], Some(p));
         }
-    }
-
-    #[proptest]
-    fn attacks_returns_squares_attacked_by_this_piece(pos: Position, s: Square) {
-        for whither in pos.attacks(s) {
-            assert!(pos
-                .attackers(whither, pos[s].unwrap().color())
-                .any(|whence| whence == s))
-        }
-    }
-
-    #[proptest]
-    fn attacks_returns_empty_iterator_if_square_is_not_occupied(
-        pos: Position,
-        #[filter(#pos[#s].is_none())] s: Square,
-    ) {
-        assert_eq!(pos.attacks(s).len(), 0);
-    }
-
-    #[proptest]
-    fn attackers_returns_squares_from_where_pieces_of_a_color_can_attack(
-        pos: Position,
-        s: Square,
-        c: Color,
-    ) {
-        for whence in pos.attackers(s, c) {
-            assert!(pos.attacks(whence).any(|whither| whither == s))
-        }
-    }
-
-    #[proptest]
-    fn checkers_returns_squares_of_pieces_giving_check(pos: Position) {
-        assert_eq!(
-            pos.checkers().collect::<Vec<_>>(),
-            pos.by_piece(Piece(pos.turn(), Role::King))
-                .flat_map(|s| pos.attackers(s, !pos.turn()))
-                .collect::<Vec<_>>(),
-        )
     }
 
     #[proptest]


### PR DESCRIPTION
## Test results @ clock("3s", "25ms") / 2 threads

### Gauntlet
> `cutechess-cli -tournament gauntlet -games 2 -rounds 800 -concurrency 3 -ratinginterval 10 -resultformat wide -engine conf=??? -engine conf=Loki-3.5.0 -engine conf=sofcheck-0.9.1 -engine conf=shenyu-1.0.1 -engine conf=gopher-0.2.3 -engine conf=gunborg-1.35 -engine conf=fatalii-0.4.0 -each proto=uci option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 ???                           -28       7    7200    2192    2778    2230   3307.0   45.9%   31.0% 
   1 Loki-3.5.0                    134      17    1200     646     204     350    821.0   68.4%   29.2% 
   2 sofcheck-0.9.1                131      17    1200     632     201     367    815.5   68.0%   30.6% 
   3 gopher-0.2.3                    1      15    1200     361     357     482    602.0   50.2%   40.2% 
   4 gunborg-1.35                   -8      17    1200     437     465     298    586.0   48.8%   24.8% 
   5 shenyu-1.0.1                  -17      17    1200     399     458     343    570.5   47.5%   28.6% 
   6 fatalii-0.4.0                 -60      16    1200     303     507     390    498.0   41.5%   32.5%
```

## STS
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v4.epd" -e ??? -t 16 --movetime 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 16, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v4.epd: 1500
Max score = 1500 x 10 = 15000
Test duration: 00h:02m:38s
Expected time to finish: 00h:03m:15s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos    100    100    100    100    100    100    100    100    100    100    100    100    100    100    100   1500
 BestCnt     38     30     45     39     45     41     32     26     29     54     25     46     43     49     25    567
   Score    631    551    675    656    719    876    599    511    509    784    575    741    647    753    629   9856
Score(%)   63.1   55.1   67.5   65.6   71.9   87.6   59.9   51.1   50.9   78.4   57.5   74.1   64.7   75.3   62.9   65.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 87.6%, "Re-Capturing"
2. STS 10, 78.4%, "Simplification"
3. STS 14, 75.3%, "Queens and Rooks to the 7th rank"
4. STS 12, 74.1%, "Center Control"
5. STS 05, 71.9%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 09, 50.9%, "Advancement of a/b/c Pawns"
2. STS 08, 51.1%, "Advancement of f/g/h Pawns"
3. STS 02, 55.1%, "Open Files and Diagonals"
4. STS 11, 57.5%, "Activity of the King"
5. STS 07, 59.9%, "Offer of Simplification"
```


