### PR TITLE
Avoid heap allocation within PVS

### DIFF
--- a/chess/src/move.rs
+++ b/chess/src/move.rs
@@ -1,10 +1,52 @@
 use crate::{Promotion, Role, Square};
+use bitflags::bitflags;
 use derive_more::{DebugCustom, Deref, Display, Error};
 use shakmaty as sm;
 use std::str::FromStr;
 use test_strategy::Arbitrary;
 use util::{Binary, Bits};
 use vampirc_uci::UciMove;
+
+bitflags! {
+    /// Characteristics of a [`Move`] in the context of a [`Position`][`crate::Position`].
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+    pub struct MoveKind: u8 {
+        const ANY =         0b00000001;
+        const CASTLE =      0b00000010;
+        const PROMOTION =   0b00000100;
+        const CAPTURE =     0b00001000;
+    }
+}
+
+#[doc(hidden)]
+impl From<&sm::Move> for MoveKind {
+    #[inline]
+    fn from(m: &sm::Move) -> Self {
+        let mut kind = Self::ANY;
+
+        if m.is_castle() {
+            kind |= MoveKind::CASTLE
+        }
+
+        if m.is_promotion() {
+            kind |= MoveKind::PROMOTION
+        }
+
+        if m.is_capture() {
+            kind |= MoveKind::CAPTURE;
+        }
+
+        kind
+    }
+}
+
+#[doc(hidden)]
+impl From<&mut sm::Move> for MoveKind {
+    #[inline]
+    fn from(m: &mut sm::Move) -> Self {
+        (&*m).into()
+    }
+}
 
 /// A chess move.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Arbitrary, Deref)]

--- a/chess/src/move.rs
+++ b/chess/src/move.rs
@@ -15,6 +15,7 @@ bitflags! {
         const CASTLE =      0b00000010;
         const PROMOTION =   0b00000100;
         const CAPTURE =     0b00001000;
+        const EN_PASSANT =  0b00010000;
     }
 }
 
@@ -34,6 +35,10 @@ impl From<&sm::Move> for MoveKind {
 
         if m.is_capture() {
             kind |= MoveKind::CAPTURE;
+        }
+
+        if m.is_en_passant() {
+            kind |= MoveKind::EN_PASSANT;
         }
 
         kind

--- a/chess/src/move.rs
+++ b/chess/src/move.rs
@@ -323,10 +323,10 @@ mod tests {
 
     #[proptest]
     fn move_context_has_an_equivalent_shakmaty_representation(
-        #[filter(#pos.clone().moves(MoveKind::ANY).len() > 0)] pos: Position,
+        #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
         selector: Selector,
     ) {
-        let (m, _) = selector.select(pos.moves(MoveKind::ANY));
+        let m = selector.select(pos.moves(MoveKind::ANY));
         assert_eq!(MoveContext::from(<sm::Move as From<_>>::from(m)), m);
     }
 }

--- a/chess/src/position.rs
+++ b/chess/src/position.rs
@@ -1,52 +1,10 @@
-use crate::{Color, Fen, Move, MoveContext, Outcome, Piece, Role, Square};
-use bitflags::bitflags;
+use crate::{Color, Fen, Move, MoveContext, MoveKind, Outcome, Piece, Role, Square};
 use derive_more::{DebugCustom, Display, Error};
 use proptest::{prelude::*, sample::Selector};
 use shakmaty as sm;
 use std::{convert::TryFrom, num::NonZeroU32, ops::Index};
 use test_strategy::Arbitrary;
 use util::Bits;
-
-bitflags! {
-    /// Characteristics of a [`Move`] in the context of a [`Position`].
-    #[derive(Default)]
-    pub struct MoveKind: u8 {
-        const ANY =         0b00000001;
-        const CASTLE =      0b00000010;
-        const PROMOTION =   0b00000100;
-        const CAPTURE =     0b00001000;
-    }
-}
-
-#[doc(hidden)]
-impl From<&sm::Move> for MoveKind {
-    #[inline]
-    fn from(m: &sm::Move) -> Self {
-        let mut kind = Self::ANY;
-
-        if m.is_castle() {
-            kind |= MoveKind::CASTLE
-        }
-
-        if m.is_promotion() {
-            kind |= MoveKind::PROMOTION
-        }
-
-        if m.is_capture() {
-            kind |= MoveKind::CAPTURE;
-        }
-
-        kind
-    }
-}
-
-#[doc(hidden)]
-impl From<&mut sm::Move> for MoveKind {
-    #[inline]
-    fn from(m: &mut sm::Move) -> Self {
-        (&*m).into()
-    }
-}
 
 pub type Zobrist = Bits<u64, 64>;
 

--- a/search/src/transposition.rs
+++ b/search/src/transposition.rs
@@ -332,21 +332,23 @@ mod tests {
         #[by_ref]
         #[filter(#tt.capacity() > 1)]
         tt: TranspositionTable,
-        #[filter(#pos.clone().moves(MoveKind::ANY).len() > 0)] pos: Position,
+        #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
         #[filter(#d > Depth::new(0))] d: Depth,
         s: Score,
         selector: Selector,
     ) {
-        let (m, next) = selector.select(pos.moves(MoveKind::ANY));
+        let m = *selector.select(pos.moves(MoveKind::ANY));
+        let mut next = pos.clone();
+        next.play(m)?;
         prop_assume!(next.moves(MoveKind::ANY).len() > 0);
 
-        let (n, _) = selector.select(next.moves(MoveKind::ANY));
+        let n = *selector.select(next.moves(MoveKind::ANY));
 
-        let t = Transposition::lower(d, s, *m);
+        let t = Transposition::lower(d, s, m);
         tt.unset(pos.zobrist());
         tt.set(pos.zobrist(), t);
 
-        let u = Transposition::lower(d, -s, *n);
+        let u = Transposition::lower(d, -s, n);
         tt.unset(next.zobrist());
         tt.set(next.zobrist(), u);
 


### PR DESCRIPTION
### SPRT
> `cutechess-cli -sprt elo0=-5 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 1000 -concurrency 3 -ratinginterval 10 -resultformat wide -engine conf=dev -engine conf=base -each proto=uci option.Threads=2 option.Hash=32 tc=3+0.025`

```
Score of dev vs base: 249 - 203 - 565  [0.523] 1017
...      dev playing White: 129 - 98 - 282  [0.530] 509
...      dev playing Black: 120 - 105 - 283  [0.515] 508
...      White vs Black: 234 - 218 - 565  [0.508] 1017
Elo difference: 15.7 +/- 14.2, LOS: 98.5 %, DrawRatio: 55.6 %
SPRT: llr 2.99 (101.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```