### PR TITLE
Tweak ply, value, and score bounds

### DIFF
--- a/lib/search/limits.rs
+++ b/lib/search/limits.rs
@@ -50,11 +50,11 @@ impl FromStr for Limits {
 }
 
 impl Limits {
-    /// Maximum depth or [`Depth::upper()`].
+    /// Maximum depth or [`Depth::UPPER`].
     pub fn depth(&self) -> Depth {
         match self {
             Limits::Depth(d) => *d,
-            _ => Depth::upper(),
+            _ => Depth::UPPER,
         }
     }
 
@@ -102,9 +102,9 @@ mod tests {
 
     #[proptest]
     fn depth_returns_max_by_default(t: Duration, i: Duration) {
-        assert_eq!(Limits::None.depth(), Depth::upper());
-        assert_eq!(Limits::Time(t).depth(), Depth::upper());
-        assert_eq!(Limits::Clock(t, i).depth(), Depth::upper());
+        assert_eq!(Limits::None.depth(), Depth::UPPER);
+        assert_eq!(Limits::Time(t).depth(), Depth::UPPER);
+        assert_eq!(Limits::Clock(t, i).depth(), Depth::UPPER);
     }
 
     #[proptest]

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -3,9 +3,9 @@ use crate::util::{Bounds, Saturating};
 pub struct PlyBounds;
 
 impl Bounds for PlyBounds {
-    type Integer = i16;
+    type Integer = i8;
     const LOWER: Self::Integer = -Self::UPPER;
-    const UPPER: Self::Integer = 383;
+    const UPPER: Self::Integer = 127;
 }
 
 /// The number of half-moves played.

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -62,8 +62,8 @@ impl Transposition {
     /// Bounds for the exact score.
     pub fn bounds(&self) -> RangeInclusive<Score> {
         match self.kind {
-            Kind::Lower => self.score..=Score::upper(),
-            Kind::Upper => Score::lower()..=self.score,
+            Kind::Lower => self.score..=Score::UPPER,
+            Kind::Upper => Score::LOWER..=self.score,
             Kind::Exact => self.score..=self.score,
         }
     }
@@ -84,7 +84,7 @@ impl Transposition {
     }
 }
 
-type Signature = Bits<u32, 27>;
+type Signature = Bits<u32, 28>;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Arbitrary)]
 struct SignedTransposition(Transposition, Signature);

--- a/lib/search/value.rs
+++ b/lib/search/value.rs
@@ -1,4 +1,4 @@
-use crate::search::{PlyBounds, Score, ScoreBounds};
+use crate::search::Score;
 use crate::util::{Bounds, Saturating};
 use std::fmt;
 
@@ -7,7 +7,7 @@ pub struct ValueBounds;
 impl Bounds for ValueBounds {
     type Integer = i16;
     const LOWER: Self::Integer = -Self::UPPER;
-    const UPPER: Self::Integer = ScoreBounds::UPPER - PlyBounds::UPPER - 1;
+    const UPPER: Self::Integer = 8000;
 }
 
 /// A position's static evaluation.
@@ -15,6 +15,6 @@ pub type Value = Saturating<ValueBounds>;
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&Score::saturate(self.get()), f)
+        <Score as fmt::Display>::fmt(&self.cast(), f)
     }
 }

--- a/lib/util/saturating.rs
+++ b/lib/util/saturating.rs
@@ -16,15 +16,11 @@ use test_strategy::Arbitrary;
 pub struct Saturating<T: Bounds>(#[strategy(T::LOWER..=T::UPPER)] T::Integer);
 
 impl<T: Bounds> Saturating<T> {
-    /// Returns the lower bound.
-    pub const fn lower() -> Self {
-        Saturating(T::LOWER)
-    }
+    /// The lower bound.
+    pub const LOWER: Self = Saturating(T::LOWER);
 
-    /// Returns the upper bound.
-    pub const fn upper() -> Self {
-        Saturating(T::UPPER)
-    }
+    /// The upper bound.
+    pub const UPPER: Self = Saturating(T::UPPER);
 
     /// Constructs `Self` from the raw integer.
     ///
@@ -37,7 +33,7 @@ impl<T: Bounds> Saturating<T> {
     }
 
     /// Returns the raw integer.
-    pub fn get(&self) -> T::Integer {
+    pub const fn get(&self) -> T::Integer {
         self.0
     }
 
@@ -252,7 +248,7 @@ mod tests {
     fn saturate_caps_if_greater_than_max(#[strategy(AsymmetricBounds::UPPER + 1..)] i: i8) {
         assert_eq!(
             Saturating::<AsymmetricBounds>::saturate(i),
-            Saturating::<AsymmetricBounds>::upper()
+            Saturating::<AsymmetricBounds>::UPPER
         );
     }
 
@@ -260,7 +256,7 @@ mod tests {
     fn saturate_caps_if_smaller_than_min(#[strategy(..AsymmetricBounds::LOWER)] i: i8) {
         assert_eq!(
             Saturating::<AsymmetricBounds>::saturate(i),
-            Saturating::<AsymmetricBounds>::lower()
+            Saturating::<AsymmetricBounds>::LOWER
         );
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn policy=round -concurrency 3 -ratinginterval 10 -resultformat wide -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -43       5    9000    1871    2987    4142   3942.0   43.8%   46.0% 
   1 Nawito-22.07                   49       9    3000    1014     593    1393   1710.5   57.0%   46.4% 
   2 dumb-1.11                      43      10    3000    1063     693    1244   1685.0   56.2%   41.5% 
   3 Fridolin-4.0                   38       9    3000     910     585    1505   1662.5   55.4%   50.2%
```

### STS
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:07s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     58     52     52     52     55     48     43     46     44     53     41     44     41     49     38    716
   Score   7052   6253   6535   7028   7052   7502   6188   5826   5551   6523   5892   5912   5874   5934   6166  95288
Score(%)   83.0   78.2   76.0   79.0   83.0   93.8   75.5   72.8   78.2   82.6   84.2   79.9   78.3   75.1   84.5   80.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 93.8%, "Re-Capturing"
2. STS 15, 84.5%, "Avoid Pointless Exchange"
3. STS 11, 84.2%, "Activity of the King"
4. STS 01, 83.0%, "Undermining"
5. STS 05, 83.0%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 08, 72.8%, "Advancement of f/g/h Pawns"
2. STS 14, 75.1%, "Queens and Rooks to the 7th rank"
3. STS 07, 75.5%, "Offer of Simplification"
4. STS 03, 76.0%, "Knight Outposts"
5. STS 02, 78.2%, "Open Files and Diagonals"
```