### PR TITLE
Implement logic to detect threefold repetitions

### DIFF
--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -306,7 +306,7 @@ mod tests {
 
     #[proptest]
     fn move_context_has_an_equivalent_shakmaty_representation(
-        #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
+        #[filter(#pos.outcome().is_none())] pos: Position,
         selector: Selector,
     ) {
         let m = selector.select(pos.moves(MoveKind::ANY));

--- a/lib/chess/outcome.rs
+++ b/lib/chess/outcome.rs
@@ -11,11 +11,14 @@ pub enum Outcome {
     #[display(fmt = "stalemate")]
     Stalemate,
 
-    #[display(fmt = "draw by insufficient material")]
-    DrawByInsufficientMaterial,
+    #[display(fmt = "draw by threefold repetition")]
+    DrawByThreefoldRepetition,
 
     #[display(fmt = "draw by the 50-move rule")]
     DrawBy50MoveRule,
+
+    #[display(fmt = "draw by insufficient material")]
+    DrawByInsufficientMaterial,
 }
 
 impl Outcome {

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -178,6 +178,13 @@ impl Position {
         sm::Position::is_stalemate(&self.0)
     }
 
+    /// Whether the game is a draw by the [50-move rule].
+    ///
+    /// [50-move rule]: https://en.wikipedia.org/wiki/Fifty-move_rule
+    pub fn is_draw_by_50_move_rule(&self) -> bool {
+        self.halfmoves() >= 100
+    }
+
     /// Whether this position has [insufficient material].
     ///
     /// [insufficient material]: https://www.chessprogramming.org/Material#InsufficientMaterial
@@ -191,7 +198,7 @@ impl Position {
             Some(Outcome::Checkmate(!self.turn()))
         } else if self.is_stalemate() {
             Some(Outcome::Stalemate)
-        } else if self.halfmoves() >= 100 {
+        } else if self.is_draw_by_50_move_rule() {
             Some(Outcome::DrawBy50MoveRule)
         } else if self.is_material_insufficient() {
             Some(Outcome::DrawByInsufficientMaterial)

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -161,7 +161,7 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn material_evaluation_is_symmetric(#[filter(!#pos.is_check())] pos: Position) {
+    fn material_evaluation_is_symmetric(#[filter(#pos.clone().pass().is_ok())] pos: Position) {
         let mut mirror = pos.clone();
         assert_eq!(mirror.pass(), Ok(()));
         assert_eq!(
@@ -182,7 +182,7 @@ mod tests {
 
     #[proptest]
     fn play_updates_accumulator(
-        #[filter(#pos.moves(MoveKind::ANY).len() > 0)] mut pos: Position,
+        #[filter(#pos.outcome().is_none())] mut pos: Position,
         selector: Selector,
     ) {
         let m = *selector.select(pos.moves(MoveKind::ANY));
@@ -192,7 +192,7 @@ mod tests {
     }
 
     #[proptest]
-    fn pass_updates_accumulator(#[filter(!#pos.is_check())] mut pos: Position) {
+    fn pass_updates_accumulator(#[filter(#pos.clone().pass().is_ok())] mut pos: Position) {
         let mut e = Evaluator::own(pos.clone());
         assert_eq!(e.pass(), pos.pass());
         assert_eq!(e, Evaluator::own(pos));

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -310,7 +310,7 @@ mod tests {
         #[by_ref]
         #[filter(#tt.capacity() > 1)]
         tt: TranspositionTable,
-        #[filter(#pos.moves(MoveKind::ANY).len() > 0)] pos: Position,
+        #[filter(#pos.outcome().is_none())] pos: Position,
         #[filter(#d > Depth::new(0))] d: Depth,
         s: Score,
         selector: Selector,


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn policy=round -concurrency 3 -ratinginterval 10 -resultformat wide -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -42       6    9000    2104    3180    3716   3962.0   44.0%   41.3% 
   1 Nawito-22.07                   50       9    3000    1077     645    1278   1716.0   57.2%   42.6% 
   2 dumb-1.11                      39      10    3000    1099     763    1138   1668.0   55.6%   37.9% 
   3 Fridolin-4.0                   36       9    3000    1004     696    1300   1654.0   55.1%   43.3%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:08s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     46     52     52     56     45     44     44     51     51     36     43     48     49     40    719
   Score   7459   5883   6593   7165   7143   7367   6225   5857   5890   6470   5328   5814   6161   6358   6304  96017
Score(%)   87.8   73.5   76.7   80.5   84.0   92.1   75.9   73.2   83.0   81.9   76.1   78.6   82.1   80.5   86.4   80.8

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 92.1%, "Re-Capturing"
2. STS 01, 87.8%, "Undermining"
3. STS 15, 86.4%, "Avoid Pointless Exchange"
4. STS 05, 84.0%, "Bishop vs Knight"
5. STS 09, 83.0%, "Advancement of a/b/c Pawns"

:: Top 5 STS with low result ::
1. STS 08, 73.2%, "Advancement of f/g/h Pawns"
2. STS 02, 73.5%, "Open Files and Diagonals"
3. STS 07, 75.9%, "Offer of Simplification"
4. STS 11, 76.1%, "Activity of the King"
5. STS 03, 76.7%, "Knight Outposts"
```