### PR TITLE
Decouple PV from TranspositionTable

### DIFF
--- a/benches/ttm.rs
+++ b/benches/ttm.rs
@@ -26,7 +26,7 @@ fn ttm(c: &mut Criterion, edps: &[(&str, &str)]) {
             || (Searcher::with_options(options), positions.next().unwrap()),
             |(s, (pos, m))| {
                 let timer = Instant::now();
-                for d in 1..=DepthBounds::UPPER {
+                for d in 0..=DepthBounds::UPPER {
                     let pv = s.search::<1>(pos, Limits::Depth(Depth::new(d)));
                     if pv.first() == Some(m) || timer.elapsed() >= Duration::from_millis(80) {
                         break;

--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -107,8 +107,23 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
+    fn empty_constructs_board_with_no_squares() {
+        assert_eq!(Bitboard::empty().into_iter().count(), 0);
+    }
+
+    #[proptest]
+    fn full_constructs_board_with_all_squares() {
+        assert_eq!(Bitboard::full().into_iter().count(), 64);
+    }
+
+    #[proptest]
     fn len_returns_number_of_squares_on_the_board(bb: Bitboard) {
         assert_eq!(bb.len(), bb.into_iter().count());
+    }
+
+    #[proptest]
+    fn is_empty_returns_whether_there_are_squares_on_the_board(bb: Bitboard) {
+        assert_eq!(bb.is_empty(), bb.into_iter().count() == 0);
     }
 
     #[proptest]

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -12,13 +12,6 @@ pub enum Role {
     King,
 }
 
-impl Role {
-    /// Returns an iterator over [`Role`]s.
-    pub fn iter() -> impl DoubleEndedIterator<Item = Self> + ExactSizeIterator {
-        sm::Role::ALL.into_iter().map(Role::from)
-    }
-}
-
 #[doc(hidden)]
 impl From<Role> for sm::Role {
     fn from(r: Role) -> Self {

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::arc_with_non_send_sync)]
 #![feature(const_maybe_uninit_write, const_mut_refs, const_transmute_copy)]
 
 /// Chess domain types.

--- a/lib/search/line.rs
+++ b/lib/search/line.rs
@@ -21,11 +21,6 @@ pub struct Line<const N: usize>(
 );
 
 impl<const N: usize> Line<N> {
-    /// Returns an empty sequence.
-    pub fn empty() -> Self {
-        Self::default()
-    }
-
     /// The number of moves in this sequence.
     pub fn len(&self) -> usize {
         self.0.len()
@@ -42,12 +37,24 @@ impl<const N: usize> Line<N> {
     }
 }
 
+/// Extends a [`Line`] with an iterator of [`Move`]s.
+///
+/// The sequence might be truncated if the number of moves exceeds the internal capacity.
+impl<const N: usize> Extend<Move> for Line<N> {
+    fn extend<T: IntoIterator<Item = Move>>(&mut self, moves: T) {
+        let limit = N - self.len();
+        self.0.extend(moves.into_iter().take(limit));
+    }
+}
+
 /// Create a [`Line`] from an iterator of [`Move`]s.
 ///
 /// The sequence might be truncated if the number of moves exceeds the internal capacity.
 impl<const N: usize> FromIterator<Move> for Line<N> {
     fn from_iter<I: IntoIterator<Item = Move>>(moves: I) -> Self {
-        Line(moves.into_iter().take(N).collect())
+        let mut line = Line::default();
+        line.extend(moves);
+        line
     }
 }
 

--- a/lib/search/options.rs
+++ b/lib/search/options.rs
@@ -12,11 +12,11 @@ pub struct Options {
     /// The size of the transposition table in bytes.
     ///
     /// This is an upper limit, the actual memory allocation may be smaller.
-    #[strategy(0usize..=1024)]
+    #[strategy(..=1024usize)]
     pub hash: usize,
 
     /// The number of threads to use while searching.
-    #[strategy((1usize..=4).prop_filter_map("zero", |t| NonZeroUsize::new(t)))]
+    #[strategy((1..=4usize).prop_filter_map("zero", |t| NonZeroUsize::new(t)))]
     pub threads: NonZeroUsize,
 }
 

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -1,23 +1,50 @@
-use crate::search::{Depth, Line, PlyBounds, Score};
-use crate::util::Bounds;
-use derive_more::{Constructor, Deref};
+use crate::search::{Depth, DepthBounds, Line, Ply, Score};
+use crate::{chess::Move, util::Bounds};
+use derive_more::{Deref, IntoIterator};
+use std::{cmp::Ordering, iter::once, mem, ops::Neg};
 use test_strategy::Arbitrary;
 
 /// The [principal variation].
 ///
 /// [principal variation]: https://www.chessprogramming.org/Principal_Variation
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Arbitrary, Constructor, Deref)]
-pub struct Pv<const N: usize = { PlyBounds::UPPER as _ }> {
-    depth: Depth,
+#[derive(Debug, Clone, Eq, PartialEq, Arbitrary, Deref, IntoIterator)]
+pub struct Pv<const N: usize = { DepthBounds::UPPER as _ }> {
     score: Score,
+    depth: Depth,
+    #[filter(#ply >= 0)]
+    ply: Ply,
     #[deref]
+    #[into_iterator(owned, ref, ref_mut)]
     line: Line<N>,
 }
 
 impl<const N: usize> Pv<N> {
-    /// The depth searched.
-    pub fn depth(&self) -> Depth {
-        self.depth
+    /// Constructs a pv.
+    pub fn new<I>(score: Score, depth: Depth, ply: Ply, line: I) -> Self
+    where
+        I: IntoIterator<Item = Move>,
+    {
+        Pv {
+            score,
+            depth,
+            ply,
+            line: line.into_iter().collect(),
+        }
+    }
+
+    /// Constructs a pv leaf.
+    pub fn leaf(score: Score, depth: Depth, ply: Ply) -> Self {
+        Self::new(score, depth, ply, [])
+    }
+
+    /// Constructs a drawn pv leaf.
+    pub fn drawn(depth: Depth, ply: Ply) -> Self {
+        Self::leaf(Score::new(0), depth, ply)
+    }
+
+    /// Constructs a lost pv leaf.
+    pub fn lost(depth: Depth, ply: Ply) -> Self {
+        Self::leaf(Score::LOWER.normalize(ply), depth, ply)
     }
 
     /// The score from the point of view of the side to move.
@@ -25,8 +52,157 @@ impl<const N: usize> Pv<N> {
         self.score
     }
 
+    /// The depth searched.
+    pub fn depth(&self) -> Depth {
+        self.depth
+    }
+
+    /// The ply reached.
+    pub fn ply(&self) -> Ply {
+        if self.ply < 0 {
+            -self.ply
+        } else {
+            self.ply
+        }
+    }
+
+    /// The tempo bonus from the point of view of the side to move.
+    pub fn tempo(&self) -> Ply {
+        if self.ply < 0 {
+            -(self.ply + self.depth)
+        } else {
+            -(self.ply - self.depth)
+        }
+    }
+
     /// The strongest [`Line`].
     pub fn line(&self) -> &Line<N> {
         &self.line
+    }
+
+    /// Continues the [`Line`] from the given [`Move`].
+    pub fn shift(mut self, m: Move) -> Pv<N> {
+        let tail = mem::take(&mut self.line);
+        self.line.extend(once(m).chain(tail));
+        self
+    }
+}
+
+impl<const N: usize> Ord for Pv<N> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.score(), self.tempo()).cmp(&(other.score(), other.tempo()))
+    }
+}
+
+impl<const N: usize> PartialOrd for Pv<N> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T, const N: usize> PartialEq<T> for Pv<N>
+where
+    Score: PartialEq<T>,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.score.eq(other)
+    }
+}
+
+impl<T, const N: usize> PartialOrd<T> for Pv<N>
+where
+    Score: PartialOrd<T>,
+{
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+        self.score.partial_cmp(other)
+    }
+}
+
+impl<const N: usize> Neg for Pv<N> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Pv::new(-self.score, self.depth, -self.ply, self.line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn score_returns_score(pv: Pv<3>) {
+        assert_eq!(pv.score(), pv.score);
+    }
+
+    #[proptest]
+    fn depth_returns_depth(pv: Pv<3>) {
+        assert_eq!(pv.depth(), pv.depth);
+    }
+
+    #[proptest]
+    fn ply_returns_ply(pv: Pv<3>) {
+        assert_eq!(pv.ply().get(), pv.ply.get().abs());
+    }
+
+    #[proptest]
+    fn line_returns_line(pv: Pv<3>) {
+        assert_eq!(pv.line(), &pv.line);
+    }
+
+    #[proptest]
+    fn negation_changes_score(pv: Pv<3>) {
+        assert_eq!(pv.clone().neg().score(), -pv.score());
+    }
+
+    #[proptest]
+    fn negation_changes_tempo(#[filter(#pv.ply() > 0)] pv: Pv<3>) {
+        assert_eq!(pv.clone().neg().tempo(), -pv.tempo());
+    }
+
+    #[proptest]
+    fn negation_preserves_depth(pv: Pv<3>) {
+        assert_eq!(pv.clone().neg().depth(), pv.depth());
+    }
+
+    #[proptest]
+    fn negation_preserves_ply(pv: Pv<3>) {
+        assert_eq!(pv.clone().neg().ply(), pv.ply());
+    }
+
+    #[proptest]
+    fn negation_preserves_line(pv: Pv<3>) {
+        assert_eq!(pv.clone().neg().line(), pv.line());
+    }
+
+    #[proptest]
+    fn shift_prepends_move(#[filter(#pv.len() < 3)] pv: Pv<3>, m: Move) {
+        assert_eq!(pv.clone().shift(m)[..], [[m].as_slice(), &pv[..]].concat());
+    }
+
+    #[proptest]
+    fn shift_truncates_line_on_overflow(#[filter(#pv.len() == 3)] pv: Pv<3>, m: Move) {
+        assert_eq!(pv.clone().shift(m)[..], [[m].as_slice(), &pv[..2]].concat());
+    }
+
+    #[proptest]
+    fn pv_with_larger_score_is_larger(p: Pv<3>, #[filter(#p.score() != #q.score())] q: Pv<3>) {
+        assert_eq!(p < q, p.score() < q.score());
+    }
+
+    #[proptest]
+    fn pvs_with_same_score_are_compared_by_tempo(
+        s: Score,
+        dp: Depth,
+        dq: Depth,
+        pp: Ply,
+        pq: Ply,
+        lp: Line<3>,
+        lq: Line<3>,
+    ) {
+        let p = Pv::<3>::new(s, dp, pp, lp);
+        let q = Pv::<3>::new(s, dq, pq, lq);
+        assert_eq!(p < q, p.tempo() < q.tempo());
     }
 }


### PR DESCRIPTION
### Gauntlet
#### Dev

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -21       5    9000    2174    2719    4107   4227.5   47.0%   45.6% 
   1 Nawito-22.07                   32       9    3000     953     674    1373   1639.5   54.6%   45.8% 
   2 Fridolin-4.0                   23       9    3000     887     687    1426   1600.0   53.3%   47.5% 
   3 dumb-1.11                       8       9    3000     879     813    1308   1533.0   51.1%   43.6%
```

#### Base

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=base -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 base                          -18       5    9000    2251    2712    4037   4269.5   47.4%   44.9% 
   1 Nawito-22.07                   28       9    3000     962     720    1318   1621.0   54.0%   43.9% 
   2 Fridolin-4.0                   21       9    3000     893     713    1394   1590.0   53.0%   46.5% 
   3 dumb-1.11                       5       9    3000     857     818    1325   1519.5   50.6%   44.2%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     57     49     56     57     58     47     42     50     42     55     41     49     43     48     39    733
   Score   7187   6145   6935   7258   7490   7502   6073   6169   5794   6707   5853   6338   6010   6402   6194  98057
Score(%)   84.6   76.8   80.6   81.6   88.1   93.8   74.1   77.1   81.6   84.9   83.6   85.6   80.1   81.0   84.8   82.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 93.8%, "Re-Capturing"
2. STS 05, 88.1%, "Bishop vs Knight"
3. STS 12, 85.6%, "Center Control"
4. STS 10, 84.9%, "Simplification"
5. STS 15, 84.8%, "Avoid Pointless Exchange"

:: Top 5 STS with low result ::
1. STS 07, 74.1%, "Offer of Simplification"
2. STS 02, 76.8%, "Open Files and Diagonals"
3. STS 08, 77.1%, "Advancement of f/g/h Pawns"
4. STS 13, 80.1%, "Pawn Play in the Center"
5. STS 03, 80.6%, "Knight Outposts"
```