### PR TITLE
Manage time more aggressively

### DIFF
--- a/lib/search/pvs.rs
+++ b/lib/search/pvs.rs
@@ -321,10 +321,10 @@ impl Searcher {
             _ => return limits.time(),
         };
 
-        let cap = clock.mul_f64(0.8);
+        let cap = clock.mul_f32(0.8);
         let excess = clock.saturating_sub(inc);
-        let moves_left = 45 - (pos.fullmoves().get() - 1).min(20);
-        inc.saturating_add(excess / moves_left).min(cap)
+        let scale = 400 / pos.fullmoves().get().min(40);
+        inc.saturating_add(excess / scale).min(cap)
     }
 
     /// Searches for the [principal variation][`Pv`].


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each proto=uci option.Threads=2 option.Hash=32 tc=3+0.025`

```
Score of dev vs base: 218 - 160 - 478  [0.534] 856
...      dev playing White: 119 - 76 - 233  [0.550] 428
...      dev playing Black: 99 - 84 - 245  [0.518] 428
...      White vs Black: 203 - 175 - 478  [0.516] 856
Elo difference: 23.6 +/- 15.4, LOS: 99.9 %, DrawRatio: 55.8 %
SPRT: llr 3 (102.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```


### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -4       5    9000    2361    2461    4178   4450.0   49.4%   46.4% 
   1 Nawito-22.07                    9       9    3000     824     744    1432   1540.0   51.3%   47.7% 
   2 Fridolin-4.0                    9       9    3000     800     721    1479   1539.5   51.3%   49.3% 
   3 dumb-1.11                      -7       9    3000     837     896    1267   1470.5   49.0%   42.2%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     59     56     51     57     62     46     45     50     47     53     41     48     42     47     42    746
   Score   7129   6676   6624   7362   7568   7474   6282   6281   5798   6546   5559   6179   5855   6428   6397  98158
Score(%)   83.9   83.5   77.0   82.7   89.0   93.4   76.6   78.5   81.7   82.9   79.4   83.5   78.1   81.4   87.6   82.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 93.4%, "Re-Capturing"
2. STS 05, 89.0%, "Bishop vs Knight"
3. STS 15, 87.6%, "Avoid Pointless Exchange"
4. STS 01, 83.9%, "Undermining"
5. STS 12, 83.5%, "Center Control"

:: Top 5 STS with low result ::
1. STS 07, 76.6%, "Offer of Simplification"
2. STS 03, 77.0%, "Knight Outposts"
3. STS 13, 78.1%, "Pawn Play in the Center"
4. STS 08, 78.5%, "Advancement of f/g/h Pawns"
5. STS 11, 79.4%, "Activity of the King"
```