### PR TITLE
Make parallel PVS more deterministic

### DIFF
--- a/bin/engine.rs
+++ b/bin/engine.rs
@@ -17,7 +17,7 @@ trait Searcher {
 impl MockSearcher {
     fn search<const N: usize>(&mut self, pos: &Position, limits: Limits) -> Pv<N> {
         let pv = Searcher::search(self, pos, limits);
-        Pv::new(pv.score(), pv.depth(), pv.ply(), pv)
+        Pv::new(pv.score(), pv.depth(), pv)
     }
 
     fn with_options(_: Options) -> Self {
@@ -93,7 +93,7 @@ impl Ai for Engine {
 mod tests {
     use super::*;
     use futures_util::StreamExt;
-    use lib::search::{Ply, Score};
+    use lib::search::Score;
     use mockall::predicate::eq;
     use proptest::sample::size_range;
     use std::time::Duration;
@@ -110,15 +110,9 @@ mod tests {
 
     #[proptest(async = "tokio")]
     #[should_panic]
-    async fn play_panics_if_there_are_no_legal_moves(
-        l: Limits,
-        pos: Position,
-        s: Score,
-        d: Depth,
-        p: Ply,
-    ) {
+    async fn play_panics_if_there_are_no_legal_moves(l: Limits, pos: Position, s: Score, d: Depth) {
         let mut strategy = Strategy::new();
-        strategy.expect_search().return_const(Pv::new(s, d, p, []));
+        strategy.expect_search().return_const(Pv::new(s, d, []));
 
         let mut engine = Engine { strategy };
         engine.play(&pos, l).await;

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -5,8 +5,14 @@ pub struct DepthBounds;
 
 impl Bounds for DepthBounds {
     type Integer = u8;
+
     const LOWER: Self::Integer = 0;
+
+    #[cfg(not(test))]
     const UPPER: Self::Integer = 31;
+
+    #[cfg(test)]
+    const UPPER: Self::Integer = 3;
 }
 
 /// The search depth.

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -4,8 +4,14 @@ pub struct PlyBounds;
 
 impl Bounds for PlyBounds {
     type Integer = i8;
+
     const LOWER: Self::Integer = -Self::UPPER;
+
+    #[cfg(not(test))]
     const UPPER: Self::Integer = 127;
+
+    #[cfg(test)]
+    const UPPER: Self::Integer = 3;
 }
 
 /// The number of half-moves played.


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each proto=uci option.Threads=2 option.Hash=32 tc=3+0.025`

```
Score of dev vs base: 893 - 883 - 2224  [0.501] 4000
...      dev playing White: 485 - 397 - 1118  [0.522] 2000
...      dev playing Black: 408 - 486 - 1106  [0.480] 2000
...      White vs Black: 971 - 805 - 2224  [0.521] 4000
Elo difference: 0.9 +/- 7.2, LOS: 59.4 %, DrawRatio: 55.6 %
SPRT: llr 0.648 (22.0%), lbound -2.94, ubound 2.94
Finished match
```


### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                             0       5    9000    2424    2413    4163   4505.5   50.1%   46.3% 
   1 Nawito-22.07                    5       9    3000     798     751    1451   1523.5   50.8%   48.4% 
   2 Fridolin-4.0                    3       9    3000     782     759    1459   1511.5   50.4%   48.6% 
   3 dumb-1.11                      -9       9    3000     833     914    1253   1459.5   48.6%   41.8%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     57     53     52     57     63     48     44     48     44     52     42     51     46     43     35    735
   Score   7101   6486   6722   7313   7469   7530   6236   6024   5661   6476   5929   6219   6239   5952   6056  97413
Score(%)   83.5   81.1   78.2   82.2   87.9   94.1   76.0   75.3   79.7   82.0   84.7   84.0   83.2   75.3   83.0   82.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.1%, "Re-Capturing"
2. STS 05, 87.9%, "Bishop vs Knight"
3. STS 11, 84.7%, "Activity of the King"
4. STS 12, 84.0%, "Center Control"
5. STS 01, 83.5%, "Undermining"

:: Top 5 STS with low result ::
1. STS 08, 75.3%, "Advancement of f/g/h Pawns"
2. STS 14, 75.3%, "Queens and Rooks to the 7th rank"
3. STS 07, 76.0%, "Offer of Simplification"
4. STS 03, 78.2%, "Knight Outposts"
5. STS 09, 79.7%, "Advancement of a/b/c Pawns"
```