### PR TITLE
Reduce depth on tt miss

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -166,6 +166,13 @@ impl Engine {
             };
         }
 
+        let depth = match tpos {
+            #[cfg(not(test))]
+            // Reductions are not exact.
+            None => depth - 1,
+            _ => depth,
+        };
+
         let score = match tpos {
             Some(t) => t.score().normalize(ply),
             None if ply >= depth => pos.value().cast(),


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each proto=uci option.Threads=2 option.Hash=32 tc=3+0.025`

```
Score of dev vs base: 910 - 868 - 2222  [0.505] 4000
...      dev playing White: 493 - 382 - 1125  [0.528] 2000
...      dev playing Black: 417 - 486 - 1097  [0.483] 2000
...      White vs Black: 979 - 799 - 2222  [0.522] 4000
Elo difference: 3.6 +/- 7.2, LOS: 84.0 %, DrawRatio: 55.5 %
SPRT: llr -1.01 (-34.2%), lbound -2.94, ubound 2.94
Finished match
```


### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            17       5    9000    2565    2116    4319   4724.5   52.5%   48.0% 
   1 Nawito-22.07                   -6       9    3000     724     777    1499   1473.5   49.1%   50.0% 
   2 Fridolin-4.0                  -14       9    3000     674     795    1531   1439.5   48.0%   51.0% 
   3 dumb-1.11                     -32       9    3000     718     993    1289   1362.5   45.4%   43.0% 

Finished match
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     56     48     60     61     60     52     43     53     42     53     42     50     53     49     38    760
   Score   6762   6117   7168   7495   7300   7502   6021   6427   5681   6754   5979   6078   6480   6140   6231  98135
Score(%)   79.6   76.5   83.3   84.2   85.9   93.8   73.4   80.3   80.0   85.5   85.4   82.1   86.4   77.7   85.4   82.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 93.8%, "Re-Capturing"
2. STS 13, 86.4%, "Pawn Play in the Center"
3. STS 05, 85.9%, "Bishop vs Knight"
4. STS 10, 85.5%, "Simplification"
5. STS 11, 85.4%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 07, 73.4%, "Offer of Simplification"
2. STS 02, 76.5%, "Open Files and Diagonals"
3. STS 14, 77.7%, "Queens and Rooks to the 7th rank"
4. STS 01, 79.6%, "Undermining"
5. STS 09, 80.0%, "Advancement of a/b/c Pawns"
```