### PR TITLE
Improve quiescence stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo install --force cargo-tarpaulin
-    - run: cargo tarpaulin --all-features --workspace --engine llvm -o Xml
+    - run: cargo tarpaulin --all-features --workspace --engine llvm -o xml
     - uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_maybe_uninit_write, const_mut_refs, const_transmute_copy)]
+#![feature(const_maybe_uninit_write, const_mut_refs)]
 
 /// Chess domain types.
 pub mod chess;

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -174,8 +174,8 @@ impl Engine {
         };
 
         let score = match tpos {
+            _ if ply >= depth => pos.value().cast(),
             Some(t) => t.score().normalize(ply),
-            None if ply >= depth => pos.value().cast(),
             None => self.nw::<1>(pos, beta, ply.cast(), ply, timer)?.score(),
         };
 


### PR DESCRIPTION
### Gauntlet

#### dev

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            13       5    9000    2573    2235    4192   4669.0   51.9%   46.6% 
   1 Fridolin-4.0                   -5       9    3000     739     780    1481   1479.5   49.3%   49.4% 
   2 Nawito-22.07                   -7       9    3000     780     838    1382   1471.0   49.0%   46.1% 
   3 dumb-1.11                     -28       9    3000     716     955    1329   1380.5   46.0%   44.3%
```

#### base

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=base -engine conf=dumb-1.11 -engine conf=Nawito-22.07 -engine conf=Fridolin-4.0 -each option.Threads=2 option.Hash=32 tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 base                            6       5    9000    2468    2304    4228   4582.0   50.9%   47.0% 
   1 Nawito-22.07                    4       9    3000     800     763    1437   1518.5   50.6%   47.9% 
   2 Fridolin-4.0                   -9       9    3000     723     805    1472   1459.0   48.6%   49.1% 
   3 dumb-1.11                     -14       9    3000     781     900    1319   1440.5   48.0%   44.0%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     61     49     53     59     57     49     47     48     41     51     42     49     43     50     34    733
   Score   7393   6327   6570   7432   7310   7542   6479   6171   5568   6533   5949   6179   5911   6322   5999  97685
Score(%)   87.0   79.1   76.4   83.5   86.0   94.3   79.0   77.1   78.4   82.7   85.0   83.5   78.8   80.0   82.2   82.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.3%, "Re-Capturing"
2. STS 01, 87.0%, "Undermining"
3. STS 05, 86.0%, "Bishop vs Knight"
4. STS 11, 85.0%, "Activity of the King"
5. STS 04, 83.5%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 03, 76.4%, "Knight Outposts"
2. STS 08, 77.1%, "Advancement of f/g/h Pawns"
3. STS 09, 78.4%, "Advancement of a/b/c Pawns"
4. STS 13, 78.8%, "Pawn Play in the Center"
5. STS 07, 79.0%, "Offer of Simplification"
```