### PR TITLE
Increase null move reductions

### DIFF
--- a/benches/ttd.rs
+++ b/benches/ttd.rs
@@ -17,7 +17,7 @@ fn ttd(c: &mut Criterion, fens: &[&str]) {
     c.benchmark_group("benches").bench_function("ttd", |b| {
         b.iter_batched_ref(
             || (Engine::with_options(options), positions.next().unwrap()),
-            |(s, pos)| s.search::<1>(pos, Depth::new(8).into()),
+            |(s, pos)| s.search::<1>(pos, Depth::new(10).into()),
             BatchSize::SmallInput,
         );
     });

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -91,9 +91,9 @@ impl Engine {
         let turn = pos.turn();
         let r = match pos.by_color(turn).len() - pos.by_piece(Piece(turn, Role::Pawn)).len() {
             ..=1 => return None,
-            2 => 0,
-            3 => 1,
-            _ => 2,
+            2 => 2,
+            3 => 3,
+            _ => 4,
         };
 
         if guess > beta {
@@ -103,7 +103,9 @@ impl Engine {
         }
     }
 
-    /// An implementation of late move pruning.
+    /// An implementation of [late move pruning].
+    ///
+    /// [late move pruning]: https://www.chessprogramming.org/Late_Move_Reductions
     fn lmp(&self, next: &Position, guess: Score, alpha: Score, depth: Depth) -> Option<Depth> {
         let r = match (alpha - guess).get() {
             ..=90 => return None,


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 158 - 107 - 377  [0.540] 642
...      dev playing White: 87 - 45 - 189  [0.565] 321
...      dev playing Black: 71 - 62 - 188  [0.514] 321
...      White vs Black: 149 - 116 - 377  [0.526] 642
Elo difference: 27.7 +/- 17.2, LOS: 99.9 %, DrawRatio: 58.7 %
SPRT: llr 2.95 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```


### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Inanis-1.2 -engine conf=Clovis3 -engine conf=Leorik-2.4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -33       5    9000    1986    2839    4175   4073.5   45.3%   46.4% 
   1 Inanis-1.2                     41       9    3000    1021     670    1309   1675.5   55.9%   43.6% 
   2 Leorik-2.4                     40       9    3000     937     594    1469   1671.5   55.7%   49.0% 
   3 Clovis3                        18       9    3000     881     722    1397   1579.5   52.6%   46.6%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:00s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     53     55     53     61     62     54     49     48     41     51     43     43     54     51     36    754
   Score   6704   6577   6903   7348   7423   7564   6481   6393   5387   6534   5896   5902   6421   6649   5968  98150
Score(%)   78.9   82.2   80.3   82.6   87.3   94.5   79.0   79.9   75.9   82.7   84.2   79.8   85.6   84.2   81.8   82.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.5%, "Re-Capturing"
2. STS 05, 87.3%, "Bishop vs Knight"
3. STS 13, 85.6%, "Pawn Play in the Center"
4. STS 11, 84.2%, "Activity of the King"
5. STS 14, 84.2%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 09, 75.9%, "Advancement of a/b/c Pawns"
2. STS 01, 78.9%, "Undermining"
3. STS 07, 79.0%, "Offer of Simplification"
4. STS 12, 79.8%, "Center Control"
5. STS 08, 79.9%, "Advancement of f/g/h Pawns"
```