### PR TITLE
Manually unroll the affine matrix multiplication to facilitate vectorization

### DIFF
--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -5,8 +5,9 @@ mod crelu;
 mod damp;
 mod evaluator;
 mod feature;
+mod input;
 mod nn;
-mod passthrough;
+mod output;
 mod psqt;
 mod transformer;
 
@@ -15,8 +16,9 @@ pub use crelu::*;
 pub use damp::*;
 pub use evaluator::*;
 pub use feature::*;
+pub use input::*;
 pub use nn::*;
-pub use passthrough::*;
+pub use output::*;
 pub use psqt::*;
 pub use transformer::*;
 

--- a/lib/nnue/affine.rs
+++ b/lib/nnue/affine.rs
@@ -18,11 +18,20 @@ where
     type Output = [i32; O];
 
     fn forward(&self, input: T) -> Self::Output {
-        let input = self.0.forward(input);
+        debug_assert_eq!(O % 8, 0);
+
         let mut output = self.2;
-        for (i, o) in output.iter_mut().enumerate() {
+        let input = self.0.forward(input);
+        for (i, o) in output.chunks_mut(8).enumerate() {
             for (j, v) in input.iter().enumerate() {
-                *o += *v as i32 * self.1[i][j] as i32
+                o[0] += *v as i32 * self.1[i * 8][j] as i32;
+                o[1] += *v as i32 * self.1[i * 8 + 1][j] as i32;
+                o[2] += *v as i32 * self.1[i * 8 + 2][j] as i32;
+                o[3] += *v as i32 * self.1[i * 8 + 3][j] as i32;
+                o[4] += *v as i32 * self.1[i * 8 + 4][j] as i32;
+                o[5] += *v as i32 * self.1[i * 8 + 5][j] as i32;
+                o[6] += *v as i32 * self.1[i * 8 + 6][j] as i32;
+                o[7] += *v as i32 * self.1[i * 8 + 7][j] as i32;
             }
         }
 
@@ -33,13 +42,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nnue::Passthrough;
+    use crate::nnue::Input;
     use test_strategy::proptest;
 
     #[proptest]
-    fn affine_multiplies_by_weight_matrix(w: [[i8; 3]; 2], i: [i8; 3]) {
+    fn affine_multiplies_by_weight_matrix(w: [[i8; 3]; 8], i: [i8; 3]) {
         assert_eq!(
-            Affine(Passthrough, w, [0; 2]).forward(i),
+            Affine(Input, w, [0; 8]).forward(i),
             [
                 i[0] as i32 * w[0][0] as i32
                     + i[1] as i32 * w[0][1] as i32
@@ -47,15 +56,42 @@ mod tests {
                 i[0] as i32 * w[1][0] as i32
                     + i[1] as i32 * w[1][1] as i32
                     + i[2] as i32 * w[1][2] as i32,
+                i[0] as i32 * w[2][0] as i32
+                    + i[1] as i32 * w[2][1] as i32
+                    + i[2] as i32 * w[2][2] as i32,
+                i[0] as i32 * w[3][0] as i32
+                    + i[1] as i32 * w[3][1] as i32
+                    + i[2] as i32 * w[3][2] as i32,
+                i[0] as i32 * w[4][0] as i32
+                    + i[1] as i32 * w[4][1] as i32
+                    + i[2] as i32 * w[4][2] as i32,
+                i[0] as i32 * w[5][0] as i32
+                    + i[1] as i32 * w[5][1] as i32
+                    + i[2] as i32 * w[5][2] as i32,
+                i[0] as i32 * w[6][0] as i32
+                    + i[1] as i32 * w[6][1] as i32
+                    + i[2] as i32 * w[6][2] as i32,
+                i[0] as i32 * w[7][0] as i32
+                    + i[1] as i32 * w[7][1] as i32
+                    + i[2] as i32 * w[7][2] as i32,
             ]
         );
     }
 
     #[proptest]
-    fn affine_adds_bias_vector(b: [i32; 2], i: [i8; 2]) {
+    fn affine_adds_bias_vector(b: [i32; 8], i: [i8; 2]) {
         assert_eq!(
-            Affine(Passthrough, [[1, 0], [0, 1]], b).forward(i),
-            [i[0] as i32 + b[0], i[1] as i32 + b[1]]
+            Affine(Input, [[1, 1]; 8], b).forward(i),
+            [
+                i[0] as i32 + i[1] as i32 + b[0],
+                i[0] as i32 + i[1] as i32 + b[1],
+                i[0] as i32 + i[1] as i32 + b[2],
+                i[0] as i32 + i[1] as i32 + b[3],
+                i[0] as i32 + i[1] as i32 + b[4],
+                i[0] as i32 + i[1] as i32 + b[5],
+                i[0] as i32 + i[1] as i32 + b[6],
+                i[0] as i32 + i[1] as i32 + b[7],
+            ]
         );
     }
 }

--- a/lib/nnue/crelu.rs
+++ b/lib/nnue/crelu.rs
@@ -1,5 +1,5 @@
 use crate::nnue::Layer;
-use num_traits::{AsPrimitive, PrimInt};
+use num_traits::AsPrimitive;
 
 /// A clipped [rectifier][ReLU].
 ///
@@ -11,25 +11,25 @@ pub struct CReLU<L>(pub(super) L);
 impl<L, I, T, const N: usize> Layer<I> for CReLU<L>
 where
     L: Layer<I, Output = [T; N]>,
-    T: PrimInt + AsPrimitive<i8> + From<i8>,
+    T: Ord + AsPrimitive<i8> + From<i8>,
 {
     type Output = [i8; N];
 
     fn forward(&self, input: I) -> Self::Output {
         self.0
             .forward(input)
-            .map(|v| v.clamp(T::zero(), i8::MAX.into()).as_())
+            .map(|v| v.clamp(0i8.into(), i8::MAX.into()).as_())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nnue::Passthrough;
+    use crate::nnue::Input;
     use test_strategy::proptest;
 
     #[proptest]
-    fn clipped_relu_saturates_between_0_and_max(l: CReLU<Passthrough>, i: [i32; 3]) {
+    fn clipped_relu_saturates_between_0_and_max(l: CReLU<Input>, i: [i32; 3]) {
         assert_eq!(l.forward(i), i.map(|v| v.clamp(0, i8::MAX as _) as _));
     }
 }

--- a/lib/nnue/damp.rs
+++ b/lib/nnue/damp.rs
@@ -1,31 +1,29 @@
 use crate::nnue::Layer;
-use num_traits::PrimInt;
 
 /// Damps neuron activation.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct Damp<L, const SCALE: i8>(pub(super) L);
+pub struct Damp<L, const SCALE: i32>(pub(super) L);
 
-impl<L, I, T, const N: usize, const SCALE: i8> Layer<I> for Damp<L, SCALE>
+impl<L, I, const N: usize, const SCALE: i32> Layer<I> for Damp<L, SCALE>
 where
-    L: Layer<I, Output = [T; N]>,
-    T: PrimInt + From<i8>,
+    L: Layer<I, Output = [i32; N]>,
 {
-    type Output = [T; N];
+    type Output = [i32; N];
 
     fn forward(&self, input: I) -> Self::Output {
-        self.0.forward(input).map(|v| v / SCALE.into())
+        self.0.forward(input).map(|v| v / SCALE)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nnue::Passthrough;
+    use crate::nnue::Input;
     use test_strategy::proptest;
 
     #[proptest]
-    fn damp_scales(l: Damp<Passthrough, 8>, i: [i8; 3]) {
+    fn damp_scales(l: Damp<Input, 8>, i: [i32; 3]) {
         assert_eq!(l.forward(i), i.map(|v| v / 8));
     }
 }

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -57,7 +57,7 @@ impl<'a> Evaluator<'a> {
     pub fn positional(&self) -> Value {
         let phase = (self.occupied().len() - 1) / 4;
         let l1: [i16; Nnue::L1] = unsafe { transmute_copy(&self.hidden) };
-        Value::saturate(NNUE.nns[phase].forward(l1)[0] / 16)
+        Value::saturate(NNUE.nns[phase].forward(l1) / 16)
     }
 
     /// The [`Position`]'s evaluation.

--- a/lib/nnue/input.rs
+++ b/lib/nnue/input.rs
@@ -1,12 +1,12 @@
 use crate::nnue::Layer;
 use num_traits::PrimInt;
 
-/// A passthrough [`Layer`].
+/// The passthrough input [`Layer`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct Passthrough;
+pub struct Input;
 
-impl<I: PrimInt, const N: usize> Layer<[I; N]> for Passthrough {
+impl<I: PrimInt, const N: usize> Layer<[I; N]> for Input {
     type Output = [I; N];
 
     fn forward(&self, input: [I; N]) -> Self::Output {

--- a/lib/nnue/output.rs
+++ b/lib/nnue/output.rs
@@ -1,0 +1,46 @@
+use crate::nnue::Layer;
+
+/// The output transformer.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct Output<L, const I: usize>(pub(super) L, pub(super) [i8; I], pub(super) i32);
+
+impl<L, T, const I: usize> Layer<T> for Output<L, I>
+where
+    L: Layer<T, Output = [i8; I]>,
+{
+    type Output = i32;
+
+    fn forward(&self, input: T) -> Self::Output {
+        let mut output = self.2;
+        let input = self.0.forward(input);
+        for (v, w) in input.into_iter().zip(self.1) {
+            output += v as i32 * w as i32;
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nnue::Input;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn output_multiplies_by_weight_vector(w: [i8; 3], i: [i8; 3]) {
+        assert_eq!(
+            Output(Input, w, 0).forward(i),
+            i[0] as i32 * w[0] as i32 + i[1] as i32 * w[1] as i32 + i[2] as i32 * w[2] as i32,
+        );
+    }
+
+    #[proptest]
+    fn output_adds_bias(b: i32, i: [i8; 2]) {
+        assert_eq!(
+            Output(Input, [1, 1], b).forward(i),
+            i[0] as i32 + i[1] as i32 + b
+        );
+    }
+}


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Inanis-1.2 -engine conf=Clovis3 -engine conf=Leorik-2.4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           109       6    9000    4609    1877    2514   5866.0   65.2%   27.9% 
   1 Inanis-1.2                   -102      11    3000     646    1501     853   1072.5   35.8%   28.4% 
   2 Clovis3                      -106      11    3000     650    1537     813   1056.5   35.2%   27.1% 
   3 Leorik-2.4                   -119      11    3000     581    1571     848   1005.0   33.5%   28.3%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:01s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     60     51     56     63     60     45     51     51     42     51     43     50     52     50     40    765
   Score   7227   6590   6898   7668   7476   7375   6567   6694   5661   6692   5953   6333   6416   6479   6150 100179
Score(%)   85.0   82.4   80.2   86.2   88.0   92.2   80.1   83.7   79.7   84.7   85.0   85.6   85.5   82.0   84.2   84.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 92.2%, "Re-Capturing"
2. STS 05, 88.0%, "Bishop vs Knight"
3. STS 04, 86.2%, "Square Vacancy"
4. STS 12, 85.6%, "Center Control"
5. STS 13, 85.5%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 09, 79.7%, "Advancement of a/b/c Pawns"
2. STS 07, 80.1%, "Offer of Simplification"
3. STS 03, 80.2%, "Knight Outposts"
4. STS 14, 82.0%, "Queens and Rooks to the 7th rank"
5. STS 02, 82.4%, "Open Files and Diagonals"
```