### PR TITLE
Change SEE to only consider material evaluation

### DIFF
--- a/bin/uci.rs
+++ b/bin/uci.rs
@@ -85,10 +85,19 @@ impl Uci {
     }
 
     fn eval(&mut self) -> Result<(), Anyhow> {
-        let pos = Evaluator::borrow(&self.position);
+        let pos = Evaluator::new(self.position.clone());
         let (material, positional, value) = match pos.turn() {
-            Color::White => (pos.material(), pos.positional(), pos.value()),
-            Color::Black => (-pos.material(), -pos.positional(), -pos.value()),
+            Color::White => (
+                pos.material().evaluate(),
+                pos.positional().evaluate(),
+                pos.evaluate(),
+            ),
+
+            Color::Black => (
+                -pos.material().evaluate(),
+                -pos.positional().evaluate(),
+                -pos.evaluate(),
+            ),
         };
 
         self.io.send(UciMessage::Info(vec![

--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -1,0 +1,43 @@
+/// Trait for transformer accumulators.
+pub trait Accumulator {
+    /// Mirrors the accumulator.
+    fn mirror(&mut self);
+
+    /// Refreshes accumulator.
+    fn refresh(&mut self, us: &[u16], them: &[u16]);
+
+    /// Updates the accumulator by adding features.
+    fn add(&mut self, us: u16, them: u16);
+
+    /// Updates the accumulator by removing features.
+    fn remove(&mut self, us: u16, them: u16);
+
+    /// Evaluates the accumulator.
+    fn evaluate(&self, phase: usize) -> i32;
+}
+
+impl<T: Accumulator, U: Accumulator> Accumulator for (T, U) {
+    fn mirror(&mut self) {
+        self.0.mirror();
+        self.1.mirror();
+    }
+
+    fn refresh(&mut self, us: &[u16], them: &[u16]) {
+        self.0.refresh(us, them);
+        self.1.refresh(us, them);
+    }
+
+    fn add(&mut self, us: u16, them: u16) {
+        self.0.add(us, them);
+        self.1.add(us, them);
+    }
+
+    fn remove(&mut self, us: u16, them: u16) {
+        self.0.remove(us, them);
+        self.1.remove(us, them);
+    }
+
+    fn evaluate(&self, phase: usize) -> i32 {
+        self.0.evaluate(phase) + self.1.evaluate(phase)
+    }
+}

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -1,0 +1,71 @@
+use crate::nnue::{Accumulator, Nnue, Vector, NNUE};
+
+/// An accumulator for the psqt transformer.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct Material(
+    #[cfg_attr(test, map(|vs: [Vector<i16, { Nnue::PHASES }>; 2]| vs.map(|v| v.map(i32::from))))]
+    [Vector<i32, { Nnue::PHASES }>; 2],
+);
+
+impl Accumulator for Material {
+    fn mirror(&mut self) {
+        self.0.reverse()
+    }
+
+    fn refresh(&mut self, us: &[u16], them: &[u16]) {
+        NNUE.psqt.refresh(us, &mut self.0[0]);
+        NNUE.psqt.refresh(them, &mut self.0[1]);
+    }
+
+    fn add(&mut self, us: u16, them: u16) {
+        NNUE.psqt.add(us, &mut self.0[0]);
+        NNUE.psqt.add(them, &mut self.0[1]);
+    }
+
+    fn remove(&mut self, us: u16, them: u16) {
+        NNUE.psqt.remove(us, &mut self.0[0]);
+        NNUE.psqt.remove(them, &mut self.0[1]);
+    }
+
+    fn evaluate(&self, phase: usize) -> i32 {
+        (self.0[0][phase] - self.0[1][phase]) / 32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{chess::Color, nnue::Feature};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn material_evaluation_is_symmetric(a: Material, #[strategy(..8usize)] phase: usize) {
+        let mut mirrored = a.clone();
+        mirrored.mirror();
+        assert_eq!(a.evaluate(phase), -mirrored.evaluate(phase));
+    }
+
+    #[proptest]
+    fn double_mirror_is_idempotent(a: Material) {
+        let mut b = a.clone();
+        b.mirror();
+        b.mirror();
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn refresh_resets_accumulator(mut a: Material, mut b: Material, f: Feature, c: Color) {
+        a.refresh(&[f.index(c)], &[f.index(!c)]);
+        b.refresh(&[f.index(c)], &[f.index(!c)]);
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn remove_reverses_add(a: Material, f: Feature, c: Color) {
+        let mut b = a.clone();
+        b.add(f.index(c), f.index(!c));
+        b.remove(f.index(c), f.index(!c));
+        assert_eq!(a, b);
+    }
+}

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -1,0 +1,66 @@
+use crate::nnue::{Accumulator, Layer, Nnue, Vector, NNUE};
+use std::mem::transmute;
+
+/// An accumulator for the feature transformer.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct Positional(
+    #[cfg_attr(test, map(|vs: [Vector<i8, { Nnue::L1 / 2 }>; 2]| vs.map(|v| v.map(i16::from))))]
+    [Vector<i16, { Nnue::L1 / 2 }>; 2],
+);
+
+impl Accumulator for Positional {
+    fn mirror(&mut self) {
+        self.0.reverse()
+    }
+
+    fn refresh(&mut self, us: &[u16], them: &[u16]) {
+        NNUE.ft.refresh(us, &mut self.0[0]);
+        NNUE.ft.refresh(them, &mut self.0[1]);
+    }
+
+    fn add(&mut self, us: u16, them: u16) {
+        NNUE.ft.add(us, &mut self.0[0]);
+        NNUE.ft.add(them, &mut self.0[1]);
+    }
+
+    fn remove(&mut self, us: u16, them: u16) {
+        NNUE.ft.remove(us, &mut self.0[0]);
+        NNUE.ft.remove(them, &mut self.0[1]);
+    }
+
+    fn evaluate(&self, phase: usize) -> i32 {
+        let l1: &Vector<i16, { Nnue::L1 }> = unsafe { transmute(&self.0) };
+        NNUE.nns[phase].forward(l1) / 16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{chess::Color, nnue::Feature};
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn double_mirror_is_idempotent(a: Positional) {
+        let mut b = a.clone();
+        b.mirror();
+        b.mirror();
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn refresh_resets_accumulator(mut a: Positional, mut b: Positional, f: Feature, c: Color) {
+        a.refresh(&[f.index(c)], &[f.index(!c)]);
+        b.refresh(&[f.index(c)], &[f.index(!c)]);
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn remove_reverses_add(a: Positional, f: Feature, c: Color) {
+        let mut b = a.clone();
+        b.add(f.index(c), f.index(!c));
+        b.remove(f.index(c), f.index(!c));
+        assert_eq!(a, b);
+    }
+}

--- a/lib/nnue/vector.rs
+++ b/lib/nnue/vector.rs
@@ -12,8 +12,8 @@ use std::fmt::Debug;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, From, Deref, DerefMut)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Arbitrary)))]
-#[repr(C, align(64))]
-pub struct Vector<T, const N: usize>(pub(crate) [T; N]);
+#[repr(C, align(32))]
+pub struct Vector<T, const N: usize>(pub [T; N]);
 
 impl<T: Default + Copy, const N: usize> Default for Vector<T, N> {
     fn default() -> Self {
@@ -31,8 +31,8 @@ impl<T, const N: usize> Vector<T, N> {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, From, Deref, DerefMut)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Arbitrary)))]
-#[repr(C, align(64))]
-pub struct Matrix<T, const I: usize, const O: usize>(pub(crate) [[T; I]; O]);
+#[repr(C, align(128))]
+pub struct Matrix<T, const I: usize, const O: usize>(pub [[T; I]; O]);
 
 impl<T: Default + Copy, const I: usize, const O: usize> Default for Matrix<T, I, O> {
     fn default() -> Self {

--- a/lib/util/buffer.rs
+++ b/lib/util/buffer.rs
@@ -11,7 +11,6 @@ use proptest::{collection::vec, prelude::*};
 #[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Arbitrary)))]
 #[debug(bound = "T: Debug")]
 #[debug(fmt = "Buffer({_0:?})")]
-#[repr(C, align(64))]
 pub struct Buffer<T, const N: usize>(
     #[cfg_attr(test, strategy(vec(any::<T>(), 0..=N).prop_map(ArrayVec::from_iter)))]
     #[deref(forward)]


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                             9       6    9000    3246    3016    2738   4615.0   51.3%   30.4% 
   1 Monolith-2                      3      10    3000    1057    1032     911   1512.5   50.4%   30.4% 
   2 Wahoo_v4                       -3      10    3000    1029    1058     913   1485.5   49.5%   30.4% 
   3 Vajolet2_2.8                  -26      10    3000     930    1156     914   1387.0   46.2%   30.5% 
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:01s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     57     50     55     68     65     50     51     49     47     59     43     52     53     51     41    791
   Score   7094   6654   6846   8008   7621   7569   6665   6668   5838   7207   5876   6462   6606   6556   6209 101879
Score(%)   83.5   83.2   79.6   90.0   89.7   94.6   81.3   83.3   82.2   91.2   83.9   87.3   88.1   83.0   85.1   85.8

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.6%, "Re-Capturing"
2. STS 10, 91.2%, "Simplification"
3. STS 04, 90.0%, "Square Vacancy"
4. STS 05, 89.7%, "Bishop vs Knight"
5. STS 13, 88.1%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 03, 79.6%, "Knight Outposts"
2. STS 07, 81.3%, "Offer of Simplification"
3. STS 09, 82.2%, "Advancement of a/b/c Pawns"
4. STS 14, 83.0%, "Queens and Rooks to the 7th rank"
5. STS 02, 83.2%, "Open Files and Diagonals"
```