### PR TITLE
Implement killer heuristics

### DIFF
--- a/lib/search.rs
+++ b/lib/search.rs
@@ -1,5 +1,6 @@
 mod depth;
 mod engine;
+mod killers;
 mod limits;
 mod options;
 mod ply;
@@ -10,6 +11,7 @@ mod value;
 
 pub use depth::*;
 pub use engine::*;
+pub use killers::*;
 pub use limits::*;
 pub use options::*;
 pub use ply::*;

--- a/lib/search/killers.rs
+++ b/lib/search/killers.rs
@@ -1,0 +1,105 @@
+use crate::chess::{Color, Move};
+use crate::search::Ply;
+
+/// A set of [killer moves] indexed by [`Ply`] and side to move.
+///
+/// [killer moves]: https://www.chessprogramming.org/Killer_Move
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct Killers<const N: usize, const P: usize>([[[Option<Move>; N]; 2]; P]);
+
+impl<const N: usize, const P: usize> Default for Killers<N, P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize, const P: usize> Killers<N, P> {
+    /// Constructs an empty set of killer moves.
+    pub const fn new() -> Self {
+        Killers([[[None; N]; 2]; P])
+    }
+
+    /// Adds a killer move to the set at a given ply for a given side to move.
+    pub fn insert(&mut self, ply: Ply, side: Color, m: Move) {
+        if let Some(ks) = self.0.get_mut(ply.get() as usize) {
+            if !ks[side as usize].contains(&Some(m)) {
+                ks[side as usize].rotate_right(1);
+                ks[side as usize][0] = Some(m);
+            }
+        }
+    }
+
+    /// Checks whether move is a known killer at a given ply for a given side to move.
+    pub fn contains(&self, ply: Ply, side: Color, m: Move) -> bool {
+        self.0
+            .get(ply.get() as usize)
+            .is_some_and(|ks| ks[side as usize].contains(&Some(m)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{search::PlyBounds, util::Bounds};
+    use proptest::sample::size_range;
+    use std::collections::HashSet;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn insert_avoids_duplicated_moves(#[filter(#p >= 0)] p: Ply, c: Color, m: Move) {
+        let mut ks = Killers::<2, { PlyBounds::UPPER as usize + 1 }>::default();
+
+        ks.insert(p, c, m);
+        ks.insert(p, c, m);
+
+        assert_eq!(ks.0[p.get() as usize][c as usize], [Some(m), None]);
+    }
+
+    #[proptest]
+    fn insert_keeps_most_recent(
+        #[filter(#p >= 0)] p: Ply,
+        c: Color,
+        #[any(size_range(2..10).lift())] ms: HashSet<Move>,
+        #[filter(!#ms.contains(&#m))] m: Move,
+    ) {
+        let mut ks = Killers::<1, { PlyBounds::UPPER as usize + 1 }>::default();
+
+        for m in ms {
+            ks.insert(p, c, m);
+        }
+
+        ks.insert(p, c, m);
+        assert_eq!(ks.0[p.get() as usize][c as usize], [Some(m)]);
+    }
+
+    #[proptest]
+    fn insert_ignores_ply_out_of_bounds(
+        mut ks: Killers<2, 1>,
+        #[filter(#p > 0)] p: Ply,
+        c: Color,
+        m: Move,
+    ) {
+        let prev = ks;
+        ks.insert(p, c, m);
+        assert_eq!(ks, prev);
+    }
+
+    #[proptest]
+    fn contains_returns_true_only_if_inserted(#[filter(#p >= 0)] p: Ply, c: Color, m: Move) {
+        let mut ks = Killers::<2, { PlyBounds::UPPER as usize + 1 }>::default();
+        assert!(!ks.contains(p, c, m));
+        ks.insert(p, c, m);
+        assert!(ks.contains(p, c, m));
+    }
+
+    #[proptest]
+    fn contains_returns_false_if_ply_out_of_bounds(
+        ks: Killers<2, 1>,
+        #[filter(#p > 0)] p: Ply,
+        c: Color,
+        m: Move,
+    ) {
+        assert!(!ks.contains(p, c, m));
+    }
+}


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            18       6    9000    3331    2865    2804   4733.0   52.6%   31.2% 
   1 Wahoo_v4                      -14      10    3000     952    1069     979   1441.5   48.0%   32.6% 
   2 Monolith-2                    -17      10    3000     954    1097     949   1428.5   47.6%   31.6% 
   3 Vajolet2_2.8                  -24      10    3000     959    1165     876   1397.0   46.6%   29.2%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:01s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     54     55     61     66     49     50     51     46     57     46     47     50     49     43    786
   Score   7405   6554   6959   7583   7595   7522   6559   6585   5538   7041   5847   6287   6378   6549   6352 100754
Score(%)   87.1   81.9   80.9   85.2   89.4   94.0   80.0   82.3   78.0   89.1   83.5   85.0   85.0   82.9   87.0   84.8

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.0%, "Re-Capturing"
2. STS 05, 89.4%, "Bishop vs Knight"
3. STS 10, 89.1%, "Simplification"
4. STS 01, 87.1%, "Undermining"
5. STS 15, 87.0%, "Avoid Pointless Exchange"

:: Top 5 STS with low result ::
1. STS 09, 78.0%, "Advancement of a/b/c Pawns"
2. STS 07, 80.0%, "Offer of Simplification"
3. STS 03, 80.9%, "Knight Outposts"
4. STS 02, 81.9%, "Open Files and Diagonals"
5. STS 08, 82.3%, "Advancement of f/g/h Pawns"
```