### PR TITLE
Skip late move pruning when move gains material

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -261,7 +261,7 @@ impl Engine {
                 let mut next = pos.clone();
                 next.play(m).assume();
 
-                if !in_check {
+                if !in_check && gain < 60 {
                     let guess = -next.clone().see(m.whither()).cast();
                     if let Some(d) = self.lmp(&next, guess, alpha, depth) {
                         if d <= ply || -self.nw(&next, -alpha, d, ply + 1, timer)? <= alpha {


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            28       6    9000    3472    2746    2782   4863.0   54.0%   30.9% 
   1 Monolith-2                    -22      10    3000     938    1126     936   1406.0   46.9%   31.2% 
   2 Vajolet2_2.8                  -29      10    3000     922    1173     905   1374.5   45.8%   30.2% 
   3 Wahoo_v4                      -33      10    3000     886    1173     941   1356.5   45.2%   31.4%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:01s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     48     59     64     61     49     49     49     46     58     43     52     53     50     40    783
   Score   7390   6444   7248   7772   7458   7430   6494   6761   5809   6929   5827   6411   6440   6482   6233 101128
Score(%)   86.9   80.5   84.3   87.3   87.7   92.9   79.2   84.5   81.8   87.7   83.2   86.6   85.9   82.1   85.4   85.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 92.9%, "Re-Capturing"
2. STS 05, 87.7%, "Bishop vs Knight"
3. STS 10, 87.7%, "Simplification"
4. STS 04, 87.3%, "Square Vacancy"
5. STS 01, 86.9%, "Undermining"

:: Top 5 STS with low result ::
1. STS 07, 79.2%, "Offer of Simplification"
2. STS 02, 80.5%, "Open Files and Diagonals"
3. STS 09, 81.8%, "Advancement of a/b/c Pawns"
4. STS 14, 82.1%, "Queens and Rooks to the 7th rank"
5. STS 11, 83.2%, "Activity of the King"
```