### PR TITLE
Stop deepening if less than 50% time remains

### DIFF
--- a/lib/util/timer.rs
+++ b/lib/util/timer.rs
@@ -5,20 +5,15 @@ use std::time::{Duration, Instant};
 #[display(fmt = "time is up!")]
 pub struct Timeout;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Timer {
     deadline: Option<Instant>,
 }
 
 impl Timer {
-    /// Constructs a timer that never elapses.
-    pub fn disarmed() -> Self {
-        Timer { deadline: None }
-    }
-
     /// Constructs a timer that elapses after the given duration.
-    pub fn start(duration: Duration) -> Self {
+    pub fn new(duration: Duration) -> Self {
         Timer {
             deadline: Instant::now().checked_add(duration),
         }
@@ -42,13 +37,13 @@ mod tests {
 
     #[proptest]
     fn timer_does_not_elapse_before_duration_expires() {
-        let timer = Timer::start(Duration::MAX);
+        let timer = Timer::new(Duration::MAX);
         assert_eq!(timer.elapsed(), Ok(()))
     }
 
     #[proptest]
     fn timer_elapses_once_duration_expires() {
-        let timer = Timer::start(Duration::ZERO);
+        let timer = Timer::new(Duration::ZERO);
         sleep(Duration::from_millis(1));
         assert_eq!(timer.elapsed(), Err(Timeout))
     }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 414 - 335 - 527  [0.531] 1276
...      dev playing White: 237 - 145 - 255  [0.572] 637
...      dev playing Black: 177 - 190 - 272  [0.490] 639
...      White vs Black: 427 - 322 - 527  [0.541] 1276
Elo difference: 21.5 +/- 14.6, LOS: 99.8 %, DrawRatio: 41.3 %
SPRT: llr 2.98 (101.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            48       6    9000    3815    2568    2617   5123.5   56.9%   29.1%
   1 Monolith-2                    -41      11    3000     895    1251     854   1322.0   44.1%   28.5%
   2 Wahoo_v4                      -45      10    3000     860    1247     893   1306.5   43.5%   29.8%
   3 Vajolet2_2.8                  -59      11    3000     813    1317     870   1248.0   41.6%   29.0%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:01m:24s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     64     53     54     65     63     51     50     48     45     59     44     47     47     52     39    781
   Score   7410   6807   6844   7689   7572   7566   6597   6476   5635   6895   5941   6182   6247   6466   6235 100562
Score(%)   87.2   85.1   79.6   86.4   89.1   94.6   80.5   81.0   79.4   87.3   84.9   83.5   83.3   81.8   85.4   84.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.6%, "Re-Capturing"
2. STS 05, 89.1%, "Bishop vs Knight"
3. STS 10, 87.3%, "Simplification"
4. STS 01, 87.2%, "Undermining"
5. STS 04, 86.4%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 79.4%, "Advancement of a/b/c Pawns"
2. STS 03, 79.6%, "Knight Outposts"
3. STS 07, 80.5%, "Offer of Simplification"
4. STS 08, 81.0%, "Advancement of f/g/h Pawns"
5. STS 14, 81.8%, "Queens and Rooks to the 7th rank"
```