### PR TITLE
Use avx2 and ssse3 instructions when available

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Ctarget-cpu=native"]

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_maybe_uninit_write, const_mut_refs)]
+#![feature(array_chunks, const_maybe_uninit_write, const_mut_refs, portable_simd)]
 
 /// Chess domain types.
 pub mod chess;

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -26,7 +26,8 @@ pub use material::*;
 pub use output::*;
 pub use positional::*;
 pub use transformer::*;
-pub use vector::*;
+
+use vector::*;
 
 /// A trained [`Nnue`].
 pub const NNUE: Nnue = Nnue::new(include_bytes!("nnue/0cd50043.nnue"));
@@ -40,9 +41,9 @@ type L3o = CReLU<Output<{ Nnue::L3 }>>;
 /// [NNUE]: https://www.chessprogramming.org/NNUE
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Nnue {
-    pub(super) ft: Transformer<i16, { Self::L0 }, { Self::L1 / 2 }>,
-    pub(super) psqt: Transformer<i32, { Self::L0 }, { Self::PHASES }>,
-    pub(super) nns: [L12<L23<L3o>>; Self::PHASES],
+    ft: Transformer<i16, { Self::L0 }, { Self::L1 / 2 }>,
+    psqt: Transformer<i32, { Self::L0 }, { Self::PHASES }>,
+    nns: [L12<L23<L3o>>; Self::PHASES],
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -52,11 +53,11 @@ const fn as_array<T, const N: usize>(slice: &[T], offset: usize) -> &[T; N] {
 }
 
 impl Nnue {
-    pub(super) const PHASES: usize = 8;
-    pub(super) const L0: usize = 64 * 64 * 11;
-    pub(super) const L1: usize = 1024;
-    pub(super) const L2: usize = 16;
-    pub(super) const L3: usize = 32;
+    const PHASES: usize = 8;
+    const L0: usize = 64 * 64 * 11;
+    const L1: usize = 1024;
+    const L2: usize = 16;
+    const L3: usize = 32;
 
     #[cfg(not(tarpaulin_include))]
     #[cfg(target_endian = "little")]
@@ -75,22 +76,22 @@ impl Nnue {
 
         let ft = unsafe {
             const B: usize = size_of::<i16>() * Nnue::L1 / 2;
-            let bias = Vector(transmute_copy(as_array::<_, B>(bytes, cursor)));
+            let bias = transmute_copy(as_array::<_, B>(bytes, cursor));
             cursor += B;
 
             const W: usize = size_of::<i16>() * Nnue::L0 * Nnue::L1 / 2;
-            let weight = Matrix(transmute_copy(as_array::<_, W>(bytes, cursor)));
+            let weight = transmute_copy(as_array::<_, W>(bytes, cursor));
             cursor += W;
 
-            Transformer(weight, bias)
+            Transformer(bias, weight)
         };
 
         let psqt = unsafe {
             const W: usize = size_of::<i32>() * Nnue::L0 * Nnue::PHASES;
-            let weight = Matrix(transmute_copy(as_array::<_, W>(bytes, cursor)));
+            let weight = transmute_copy(as_array::<_, W>(bytes, cursor));
             cursor += W;
 
-            Transformer(weight, Vector([0; Nnue::PHASES]))
+            Transformer([0; Nnue::PHASES], weight)
         };
 
         let mut phase = 0;
@@ -106,45 +107,45 @@ impl Nnue {
                 };
             }
 
-            let (l12w, l12b) = unsafe {
+            let (l12b, l12w) = unsafe {
                 const B: usize = size_of::<i32>() * Nnue::L2;
-                let bias = Vector(transmute_copy(as_array::<_, B>(bytes, cursor)));
+                let bias = transmute_copy(as_array::<_, B>(bytes, cursor));
                 cursor += B;
 
                 const W: usize = size_of::<i8>() * Nnue::L1 * Nnue::L2;
-                let weight = Matrix(transmute_copy(as_array::<_, W>(bytes, cursor)));
+                let weight = transmute_copy(as_array::<_, W>(bytes, cursor));
                 cursor += W;
 
-                (weight, bias)
+                (bias, weight)
             };
 
-            let (l23w, l23b) = unsafe {
+            let (l23b, l23w) = unsafe {
                 const B: usize = size_of::<i32>() * Nnue::L3;
-                let bias = Vector(transmute_copy(as_array::<_, B>(bytes, cursor)));
+                let bias = transmute_copy(as_array::<_, B>(bytes, cursor));
                 cursor += B;
 
                 const W: usize = size_of::<i8>() * Nnue::L2 * Nnue::L3;
-                let weight = Matrix(transmute_copy(as_array::<_, W>(bytes, cursor)));
+                let weight = transmute_copy(as_array::<_, W>(bytes, cursor));
                 cursor += W;
 
-                (weight, bias)
+                (bias, weight)
             };
 
-            let (l3ow, l3ob) = unsafe {
+            let (l3ob, l3ow) = unsafe {
                 const B: usize = size_of::<i32>();
                 let bias = transmute_copy(as_array::<_, B>(bytes, cursor));
                 cursor += B;
 
                 const W: usize = size_of::<i8>() * Nnue::L3;
-                let weight = Vector(transmute_copy(as_array::<_, W>(bytes, cursor)));
+                let weight = transmute_copy(as_array::<_, W>(bytes, cursor));
                 cursor += W;
 
-                (weight, bias)
+                (bias, weight)
             };
 
-            let l3o = CReLU(Output(l3ow, l3ob));
-            let l23 = CReLU(Affine(l23w, l23b, Damp(l3o)));
-            let l12 = CReLU(Affine(l12w, l12b, Damp(l23)));
+            let l3o = CReLU(Output(l3ob, l3ow));
+            let l23 = CReLU(Affine(l23b, l23w, Damp(l3o)));
+            let l12 = CReLU(Affine(l12b, l12w, Damp(l23)));
 
             nns[phase].write(l12);
             phase += 1;

--- a/lib/nnue/affine.rs
+++ b/lib/nnue/affine.rs
@@ -1,23 +1,22 @@
-use crate::nnue::{Axpy, Layer, Matrix, Vector};
+use crate::nnue::{Axpy, Layer};
 
 /// An [affine] transformer.
 ///
 /// [affine]: https://en.wikipedia.org/wiki/Affine_transformation
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(align(64))]
 pub struct Affine<L, const I: usize, const O: usize>(
-    pub(super) Matrix<i8, I, O>,
-    pub(super) Vector<i32, O>,
+    pub(super) [i32; O],
+    pub(super) [[i8; I]; O],
     pub(super) L,
 );
 
-impl<L: Layer<Vector<i32, O>>, const I: usize, const O: usize> Layer<Vector<i8, I>>
-    for Affine<L, I, O>
-{
+impl<L: Layer<[i32; O]>, const I: usize, const O: usize> Layer<[i8; I]> for Affine<L, I, O> {
     type Output = L::Output;
 
-    fn forward(&self, input: &Vector<i8, I>) -> Self::Output {
-        let mut output = self.1;
-        output.axpy(&self.0, input);
+    fn forward(&self, input: &[i8; I]) -> Self::Output {
+        let mut output = self.0;
+        output.axpy(&self.1, input);
         self.2.forward(&output)
     }
 }
@@ -30,24 +29,17 @@ mod tests {
 
     #[proptest]
     fn affine_multiplies_by_weight_matrix(w: [[i8; 3]; 2], i: [i8; 3]) {
-        assert_eq!(
-            Affine(w.into(), Vector::default(), Fallthrough).forward(&i.into()),
-            Vector([
-                i[0] as i32 * w[0][0] as i32
-                    + i[1] as i32 * w[0][1] as i32
-                    + i[2] as i32 * w[0][2] as i32,
-                i[0] as i32 * w[1][0] as i32
-                    + i[1] as i32 * w[1][1] as i32
-                    + i[2] as i32 * w[1][2] as i32,
-            ])
-        );
+        let mut y = [0; 2];
+        y.axpy(&w, &i);
+
+        assert_eq!(Affine([0; 2], w, Fallthrough).forward(&i), y);
     }
 
     #[proptest]
     fn affine_adds_bias_vector(b: [i32; 3], i: [i8; 1]) {
         assert_eq!(
-            Affine(Matrix([[1]; 3]), b.into(), Fallthrough).forward(&i.into()),
-            Vector([i[0] as i32 + b[0], i[0] as i32 + b[1], i[0] as i32 + b[2]])
+            Affine(b, [[1]; 3], Fallthrough).forward(&i),
+            [i[0] as i32 + b[0], i[0] as i32 + b[1], i[0] as i32 + b[2]]
         );
     }
 }

--- a/lib/nnue/crelu.rs
+++ b/lib/nnue/crelu.rs
@@ -1,4 +1,4 @@
-use crate::nnue::{Layer, Vector};
+use crate::nnue::Layer;
 use num_traits::AsPrimitive;
 
 /// A clipped [rectifier][ReLU].
@@ -7,14 +7,14 @@ use num_traits::AsPrimitive;
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct CReLU<L>(pub(super) L);
 
-impl<L, T, const N: usize> Layer<Vector<T, N>> for CReLU<L>
+impl<L, T, const N: usize> Layer<[T; N]> for CReLU<L>
 where
-    L: Layer<Vector<i8, N>>,
+    L: Layer<[i8; N]>,
     T: Ord + AsPrimitive<i8> + From<i8>,
 {
     type Output = L::Output;
 
-    fn forward(&self, input: &Vector<T, N>) -> Self::Output {
+    fn forward(&self, input: &[T; N]) -> Self::Output {
         self.0
             .forward(&input.map(|v| v.clamp(0i8.into(), i8::MAX.into()).as_()))
     }
@@ -29,8 +29,8 @@ mod tests {
     #[proptest]
     fn clipped_relu_saturates_between_0_and_max(i: [i32; 3]) {
         assert_eq!(
-            CReLU(Fallthrough).forward(&i.into()),
-            Vector(i.map(|v| v.clamp(0, i8::MAX as _) as _))
+            CReLU(Fallthrough).forward(&i),
+            i.map(|v| v.clamp(0, i8::MAX as _) as _)
         );
     }
 }

--- a/lib/nnue/damp.rs
+++ b/lib/nnue/damp.rs
@@ -1,16 +1,16 @@
-use crate::nnue::{Layer, Vector};
+use crate::nnue::Layer;
 
 /// Damps neuron activation.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Damp<L, const SCALE: i32>(pub(super) L);
 
-impl<L, const N: usize, const SCALE: i32> Layer<Vector<i32, N>> for Damp<L, SCALE>
+impl<L, const N: usize, const SCALE: i32> Layer<[i32; N]> for Damp<L, SCALE>
 where
-    L: Layer<Vector<i32, N>>,
+    L: Layer<[i32; N]>,
 {
     type Output = L::Output;
 
-    fn forward(&self, input: &Vector<i32, N>) -> Self::Output {
+    fn forward(&self, input: &[i32; N]) -> Self::Output {
         self.0.forward(&input.map(|v| v / SCALE))
     }
 }
@@ -23,9 +23,6 @@ mod tests {
 
     #[proptest]
     fn damp_scales(i: [i32; 3]) {
-        assert_eq!(
-            Damp::<_, 8>(Fallthrough).forward(&i.into()),
-            Vector(i.map(|v| v / 8))
-        );
+        assert_eq!(Damp::<_, 8>(Fallthrough).forward(&i), i.map(|v| v / 8));
     }
 }

--- a/lib/nnue/fallthrough.rs
+++ b/lib/nnue/fallthrough.rs
@@ -1,14 +1,13 @@
-use crate::nnue::{Layer, Vector};
-use num_traits::PrimInt;
+use crate::nnue::Layer;
 
 /// A fallthrough [`Layer`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Fallthrough;
 
-impl<I: PrimInt, const N: usize> Layer<Vector<I, N>> for Fallthrough {
-    type Output = Vector<I, N>;
+impl<T: Copy, const N: usize> Layer<[T; N]> for Fallthrough {
+    type Output = [T; N];
 
-    fn forward(&self, input: &Vector<I, N>) -> Self::Output {
+    fn forward(&self, input: &[T; N]) -> Self::Output {
         *input
     }
 }

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -1,11 +1,11 @@
-use crate::nnue::{Accumulator, Nnue, Vector, NNUE};
+use crate::nnue::{Accumulator, Nnue, NNUE};
 
 /// An accumulator for the psqt transformer.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Material(
-    #[cfg_attr(test, map(|vs: [Vector<i16, { Nnue::PHASES }>; 2]| vs.map(|v| v.map(i32::from))))]
-    [Vector<i32, { Nnue::PHASES }>; 2],
+    #[cfg_attr(test, map(|vs: [[i16; Nnue::PHASES]; 2]| vs.map(|v| v.map(i32::from))))]
+    [[i32; Nnue::PHASES]; 2],
 );
 
 impl Accumulator for Material {

--- a/lib/nnue/output.rs
+++ b/lib/nnue/output.rs
@@ -1,15 +1,15 @@
-use crate::nnue::{Axpy, Layer, Vector};
+use crate::nnue::{Axpy, Layer};
 
 /// The output transformer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Output<const I: usize>(pub(super) Vector<i8, I>, pub(super) i32);
+pub struct Output<const I: usize>(pub(super) i32, pub(super) [i8; I]);
 
-impl<const N: usize> Layer<Vector<i8, N>> for Output<N> {
+impl<const N: usize> Layer<[i8; N]> for Output<N> {
     type Output = i32;
 
-    fn forward(&self, input: &Vector<i8, N>) -> Self::Output {
-        let mut output = self.1;
-        output.axpy(&self.0, input);
+    fn forward(&self, input: &[i8; N]) -> Self::Output {
+        let mut output = self.0;
+        output.axpy(&self.1, input);
         output
     }
 }
@@ -21,14 +21,14 @@ mod tests {
 
     #[proptest]
     fn output_multiplies_by_weight_vector(w: [i8; 3], i: [i8; 3]) {
-        assert_eq!(
-            Output(w.into(), 0).forward(&i.into()),
-            i[0] as i32 * w[0] as i32 + i[1] as i32 * w[1] as i32 + i[2] as i32 * w[2] as i32,
-        );
+        let mut y = 0;
+        y.axpy(&w, &i);
+
+        assert_eq!(Output(0, w).forward(&i), y);
     }
 
     #[proptest]
     fn output_adds_bias(b: i32, i: [i8; 1]) {
-        assert_eq!(Output(Vector([1]), b).forward(&i.into()), i[0] as i32 + b);
+        assert_eq!(Output(b, [1]).forward(&i), i[0] as i32 + b);
     }
 }

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -1,13 +1,19 @@
-use crate::nnue::{Accumulator, Layer, Nnue, Vector, NNUE};
+use crate::nnue::{Accumulator, Layer, Nnue, NNUE};
 use std::mem::transmute;
 
 /// An accumulator for the feature transformer.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Positional(
-    #[cfg_attr(test, map(|vs: [Vector<i8, { Nnue::L1 / 2 }>; 2]| vs.map(|v| v.map(i16::from))))]
-    [Vector<i16, { Nnue::L1 / 2 }>; 2],
+    #[cfg_attr(test, map(|vs: [[i8; { Nnue::L1 / 2 }]; 2]| vs.map(|v| v.map(i16::from))))]
+    [[i16; Nnue::L1 / 2]; 2],
 );
+
+impl Default for Positional {
+    fn default() -> Self {
+        Positional([[0; Nnue::L1 / 2]; 2])
+    }
+}
 
 impl Accumulator for Positional {
     fn mirror(&mut self) {
@@ -30,7 +36,7 @@ impl Accumulator for Positional {
     }
 
     fn evaluate(&self, phase: usize) -> i32 {
-        let l1: &Vector<i16, { Nnue::L1 }> = unsafe { transmute(&self.0) };
+        let l1: &[i16; Nnue::L1] = unsafe { transmute(&self.0) };
         NNUE.nns[phase].forward(l1) / 16
     }
 }

--- a/lib/nnue/vector.rs
+++ b/lib/nnue/vector.rs
@@ -1,44 +1,21 @@
 use crate::util::Assume;
-use derive_more::{Deref, DerefMut, From};
-use std::ops::AddAssign;
+use std::mem::transmute;
+use std::ops::{AddAssign, SubAssign};
+use std::simd::{i32x4, i32x8, i8x16, i8x32, simd_swizzle, SimdInt};
 
-#[cfg(test)]
-use proptest::prelude::*;
+#[cfg(target_arch = "x86_64")]
+#[cfg(any(
+    target_feature = "avx2",
+    all(target_feature = "ssse3", target_feature = "sse2")
+))]
+use std::arch::x86_64::*;
 
-#[cfg(test)]
-use std::fmt::Debug;
-
-/// A 1D array.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, From, Deref, DerefMut)]
-#[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Arbitrary)))]
-#[repr(C, align(32))]
-pub struct Vector<T, const N: usize>(pub [T; N]);
-
-impl<T: Default + Copy, const N: usize> Default for Vector<T, N> {
-    fn default() -> Self {
-        Vector([T::default(); N])
-    }
-}
-
-impl<T, const N: usize> Vector<T, N> {
-    pub fn map<U>(self, f: fn(T) -> U) -> Vector<U, N> {
-        Vector(self.0.map(f))
-    }
-}
-
-/// A 2D array.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, From, Deref, DerefMut)]
-#[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Arbitrary)))]
-#[repr(C, align(128))]
-pub struct Matrix<T, const I: usize, const O: usize>(pub [[T; I]; O]);
-
-impl<T: Default + Copy, const I: usize, const O: usize> Default for Matrix<T, I, O> {
-    fn default() -> Self {
-        Matrix([[T::default(); I]; O])
-    }
-}
+#[cfg(target_arch = "x86")]
+#[cfg(any(
+    target_feature = "avx2",
+    all(target_feature = "ssse3", target_feature = "sse2")
+))]
+use std::arch::x86::*;
 
 /// A trait for types that implement affine transformations.
 pub trait Axpy<A: ?Sized, X: ?Sized> {
@@ -46,74 +23,167 @@ pub trait Axpy<A: ?Sized, X: ?Sized> {
     fn axpy(&mut self, a: &A, x: &X);
 }
 
-impl<const I: usize> Axpy<Vector<i8, I>, Vector<i8, I>> for i32 {
-    fn axpy(&mut self, a: &Vector<i8, I>, x: &Vector<i8, I>) {
-        for i in 0..I {
-            *self += a[i] as i32 * x[i] as i32;
+impl<const I: usize> Axpy<[i8; I], [i8; I]> for i32 {
+    fn axpy(&mut self, a: &[i8; I], x: &[i8; I]) {
+        let mut a = a.array_chunks::<32>();
+        let mut x = x.array_chunks::<32>();
+        let mut y = [0; 8];
+
+        for (a, x) in Iterator::zip(&mut a, &mut x) {
+            y.axpy(a, x);
+        }
+
+        *self += i32x8::from_array(y).reduce_sum();
+
+        let mut a = a.remainder().array_chunks::<16>();
+        let mut x = x.remainder().array_chunks::<16>();
+        let mut y = [0; 4];
+
+        for (a, x) in Iterator::zip(&mut a, &mut x) {
+            y.axpy(a, x);
+        }
+
+        *self += i32x4::from_array(y).reduce_sum();
+
+        for (a, x) in a.remainder().iter().zip(x.remainder()) {
+            *self += *x as i32 * *a as i32;
         }
     }
 }
 
-impl<const I: usize, const O: usize> Axpy<Matrix<i8, I, O>, Vector<i8, I>> for Vector<i32, O> {
-    fn axpy(&mut self, a: &Matrix<i8, I, O>, x: &Vector<i8, I>) {
-        let mut chunks = self.chunks_exact_mut(8);
+impl Axpy<[i8; 32], [i8; 32]> for [i32; 8] {
+    fn axpy(&mut self, a: &[i8; 32], x: &[i8; 32]) {
+        let (y, a, x) = (i32x8::from(*self), i8x32::from(*a), i8x32::from(*x));
 
-        for (o, y) in (&mut chunks).enumerate() {
-            for i in 0..I {
-                y[0] += x[i] as i32 * a[o * 8][i] as i32;
-                y[1] += x[i] as i32 * a[o * 8 + 1][i] as i32;
-                y[2] += x[i] as i32 * a[o * 8 + 2][i] as i32;
-                y[3] += x[i] as i32 * a[o * 8 + 3][i] as i32;
-                y[4] += x[i] as i32 * a[o * 8 + 4][i] as i32;
-                y[5] += x[i] as i32 * a[o * 8 + 5][i] as i32;
-                y[6] += x[i] as i32 * a[o * 8 + 6][i] as i32;
-                y[7] += x[i] as i32 * a[o * 8 + 7][i] as i32;
-            }
-        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(target_feature = "avx2")]
+        let (y, a, x) = (__m256i::from(y), __m256i::from(a), __m256i::from(x));
 
-        for (o, y) in chunks.into_remainder().iter_mut().enumerate() {
-            for i in 0..I {
-                *y += x[i] as i32 * a[o + (O / 8) * 8][i] as i32;
-            }
+        let mut y = y;
+        y.axpy(&a, &x);
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(target_feature = "avx2")]
+        let y = i32x8::from(y);
+
+        *self = y.to_array();
+    }
+}
+
+impl Axpy<i8x32, i8x32> for i32x8 {
+    fn axpy(&mut self, a: &i8x32, x: &i8x32) {
+        let [ah, al] = unsafe { transmute::<_, &[[i8; 16]; 2]>(a) };
+        let [xh, xl] = unsafe { transmute::<_, &[[i8; 16]; 2]>(x) };
+        let [yh, yl] = unsafe { transmute::<_, &mut [[i32; 4]; 2]>(self) };
+
+        yh.axpy(ah, xh);
+        yl.axpy(al, xl);
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(target_feature = "avx2")]
+impl Axpy<__m256i, __m256i> for __m256i {
+    fn axpy(&mut self, a: &__m256i, x: &__m256i) {
+        unsafe {
+            let p = _mm256_maddubs_epi16(*x, *a);
+            let q = _mm256_madd_epi16(p, _mm256_set1_epi16(1));
+            *self = _mm256_add_epi32(*self, q);
         }
     }
 }
 
-impl<T, const I: usize, const O: usize> Axpy<Matrix<T, O, I>, [u16]> for Vector<T, O>
+impl Axpy<[i8; 16], [i8; 16]> for [i32; 4] {
+    fn axpy(&mut self, a: &[i8; 16], x: &[i8; 16]) {
+        let (y, a, x) = (i32x4::from(*self), i8x16::from(*a), i8x16::from(*x));
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(target_feature = "ssse3", target_feature = "sse2"))]
+        let (y, a, x) = (__m128i::from(y), __m128i::from(a), __m128i::from(x));
+
+        let mut y = y;
+        y.axpy(&a, &x);
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        #[cfg(all(target_feature = "ssse3", target_feature = "sse2"))]
+        let y = i32x4::from(y);
+
+        *self = y.to_array();
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(target_feature = "ssse3", target_feature = "sse2"))]
+impl Axpy<__m128i, __m128i> for __m128i {
+    fn axpy(&mut self, a: &__m128i, x: &__m128i) {
+        unsafe {
+            let p = _mm_maddubs_epi16(*x, *a);
+            let q = _mm_madd_epi16(p, _mm_set1_epi16(1));
+            *self = _mm_add_epi32(*self, q);
+        }
+    }
+}
+
+impl Axpy<i8x16, i8x16> for i32x4 {
+    fn axpy(&mut self, a: &i8x16, x: &i8x16) {
+        let a = a.cast::<i32>();
+        let a0 = simd_swizzle!(a, [0, 4, 8, 12]);
+        let a1 = simd_swizzle!(a, [1, 5, 9, 13]);
+        let a2 = simd_swizzle!(a, [2, 6, 10, 14]);
+        let a3 = simd_swizzle!(a, [3, 7, 11, 15]);
+
+        let x = x.cast::<i32>();
+        let x0 = simd_swizzle!(x, [0, 4, 8, 12]);
+        let x1 = simd_swizzle!(x, [1, 5, 9, 13]);
+        let x2 = simd_swizzle!(x, [2, 6, 10, 14]);
+        let x3 = simd_swizzle!(x, [3, 7, 11, 15]);
+
+        *self += a0 * x0 + a1 * x1 + a2 * x2 + a3 * x3;
+    }
+}
+
+impl<const I: usize, const O: usize> Axpy<[[i8; I]; O], [i8; I]> for [i32; O] {
+    fn axpy(&mut self, a: &[[i8; I]; O], x: &[i8; I]) {
+        for (o, y) in self.iter_mut().enumerate() {
+            y.axpy(&a[o], x);
+        }
+    }
+}
+
+impl<T, const I: usize, const O: usize> Axpy<[[T; O]; I], [u16]> for [T; O]
 where
     T: Copy + AddAssign,
 {
-    fn axpy(&mut self, a: &Matrix<T, O, I>, x: &[u16]) {
-        let mut chunks = x.chunks_exact(8);
-
-        for i in &mut chunks {
-            for (o, y) in self.iter_mut().enumerate() {
-                *y += a.get(i[0] as usize).assume()[o];
-                *y += a.get(i[1] as usize).assume()[o];
-                *y += a.get(i[2] as usize).assume()[o];
-                *y += a.get(i[3] as usize).assume()[o];
-                *y += a.get(i[4] as usize).assume()[o];
-                *y += a.get(i[5] as usize).assume()[o];
-                *y += a.get(i[6] as usize).assume()[o];
-                *y += a.get(i[7] as usize).assume()[o];
-            }
+    fn axpy(&mut self, a: &[[T; O]; I], x: &[u16]) {
+        for i in x {
+            self.axpy(a, i);
         }
+    }
+}
 
-        let mut chunks = chunks.remainder().chunks_exact(4);
-
-        for i in &mut chunks {
-            for (o, y) in self.iter_mut().enumerate() {
-                *y += a.get(i[0] as usize).assume()[o];
-                *y += a.get(i[1] as usize).assume()[o];
-                *y += a.get(i[2] as usize).assume()[o];
-                *y += a.get(i[3] as usize).assume()[o];
-            }
+impl<T, const I: usize, const O: usize> Axpy<[[T; O]; I], u16> for [T; O]
+where
+    T: Copy + AddAssign,
+{
+    fn axpy(&mut self, a: &[[T; O]; I], &x: &u16) {
+        let a = a.get(x as usize).assume();
+        for (y, a) in self.iter_mut().zip(a) {
+            *y += *a
         }
+    }
+}
 
-        for i in chunks.remainder() {
-            for (o, y) in self.iter_mut().enumerate() {
-                *y += a.get(*i as usize).assume()[o]
-            }
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Invert<T>(pub T);
+
+impl<T, const I: usize, const O: usize> Axpy<[[T; O]; I], Invert<u16>> for [T; O]
+where
+    T: Copy + SubAssign,
+{
+    fn axpy(&mut self, a: &[[T; O]; I], &Invert(x): &Invert<u16>) {
+        let a = a.get(x as usize).assume();
+        for (y, a) in self.iter_mut().zip(a) {
+            *y -= *a
         }
     }
 }
@@ -123,78 +193,72 @@ mod tests {
     use super::*;
     use test_strategy::proptest;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_feature = "avx2")]
     #[proptest]
-    fn axpy_computes_inner_product_of_vectors(a: Vector<i8, 2>, x: Vector<i8, 2>) {
-        let mut y = 0;
-        y.axpy(&a, &x);
-        assert_eq!(y, a[0] as i32 * x[0] as i32 + a[1] as i32 * x[1] as i32);
+    fn axpy_supports_avx2(a: [i8; 32], x: [i8; 32], y: [i32; 8]) {
+        let x = x.map(|v| v.max(0));
+        let (ap, xp, mut yp) = (i8x32::from(a), i8x32::from(x), i32x8::from(y));
+        let (aq, xq, mut yq) = (__m256i::from(ap), __m256i::from(xp), __m256i::from(yp));
+
+        yp.axpy(&ap, &xp);
+        yq.axpy(&aq, &xq);
+
+        assert_eq!(yp, yq.into());
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(all(target_feature = "ssse3", target_feature = "sse2"))]
+    #[proptest]
+    fn axpy_supports_ssse3(a: [i8; 16], x: [i8; 16], y: [i32; 4]) {
+        let x = x.map(|v| v.max(0));
+        let (ap, xp, mut yp) = (i8x16::from(a), i8x16::from(x), i32x4::from(y));
+        let (aq, xq, mut yq) = (__m128i::from(ap), __m128i::from(xp), __m128i::from(yp));
+
+        yp.axpy(&ap, &xp);
+        yq.axpy(&aq, &xq);
+
+        assert_eq!(yp, yq.into());
     }
 
     #[proptest]
-    fn axpy_computes_inner_product_of_matrix_and_vector(a: Matrix<i8, 2, 10>, x: Vector<i8, 2>) {
-        let mut y = Vector::default();
+    fn axpy_computes_inner_product_of_vectors(a: [i8; 50], x: [i8; 50]) {
+        let x = x.map(|v| v.max(0));
+
+        let mut y = 0;
+        y.axpy(&a, &x);
+
+        assert_eq!(y, a.iter().zip(x).map(|(&a, x)| a as i32 * x as i32).sum());
+    }
+
+    #[proptest]
+    fn axpy_computes_inner_product_of_matrix_and_vector(a: [[i8; 50]; 10], x: [i8; 50]) {
+        let x = x.map(|v| v.max(0));
+
+        let mut y = [0; 10];
         y.axpy(&a, &x);
 
         assert_eq!(
             y,
-            Vector([
-                a[0][0] as i32 * x[0] as i32 + a[0][1] as i32 * x[1] as i32,
-                a[1][0] as i32 * x[0] as i32 + a[1][1] as i32 * x[1] as i32,
-                a[2][0] as i32 * x[0] as i32 + a[2][1] as i32 * x[1] as i32,
-                a[3][0] as i32 * x[0] as i32 + a[3][1] as i32 * x[1] as i32,
-                a[4][0] as i32 * x[0] as i32 + a[4][1] as i32 * x[1] as i32,
-                a[5][0] as i32 * x[0] as i32 + a[5][1] as i32 * x[1] as i32,
-                a[6][0] as i32 * x[0] as i32 + a[6][1] as i32 * x[1] as i32,
-                a[7][0] as i32 * x[0] as i32 + a[7][1] as i32 * x[1] as i32,
-                a[8][0] as i32 * x[0] as i32 + a[8][1] as i32 * x[1] as i32,
-                a[9][0] as i32 * x[0] as i32 + a[9][1] as i32 * x[1] as i32,
-            ])
+            a.map(|a| a.iter().zip(x).map(|(&a, x)| a as i32 * x as i32).sum())
         );
     }
 
     #[proptest]
     fn axpy_swizzles_matrix(
-        #[strategy([
-            [-10..10i8, -10..10i8], [-10..10i8, -10..10i8],
-            [-10..10i8, -10..10i8], [-10..10i8, -10..10i8],
-            [-10..10i8, -10..10i8], [-10..10i8, -10..10i8],
-            [-10..10i8, -10..10i8], [-10..10i8, -10..10i8],
-            [-10..10i8, -10..10i8], [-10..10i8, -10..10i8],
-        ])]
-        a: [[i8; 2]; 10],
-        #[strategy([
-            0..10u16, 0..10u16, 0..10u16, 0..10u16, 0..10u16,
-            0..10u16, 0..10u16, 0..10u16, 0..10u16, 0..10u16,
-        ])]
-        x: [u16; 10],
+        #[strategy([[-10..10i8, -10..10i8], [-10..10i8, -10..10i8], [-10..10i8, -10..10i8]])]
+        a: [[i8; 2]; 3],
+        #[strategy([0..3u16, 0..3u16, 0..3u16])] x: [u16; 3],
     ) {
-        let mut y = Vector::<_, 2>::default();
-        y.axpy(&Matrix(a), &x);
+        let mut y = [0; 2];
+        y.axpy(&a, x.as_slice());
 
         assert_eq!(
             y,
-            Vector([
-                a[x[0] as usize][0]
-                    + a[x[1] as usize][0]
-                    + a[x[2] as usize][0]
-                    + a[x[3] as usize][0]
-                    + a[x[4] as usize][0]
-                    + a[x[5] as usize][0]
-                    + a[x[6] as usize][0]
-                    + a[x[7] as usize][0]
-                    + a[x[8] as usize][0]
-                    + a[x[9] as usize][0],
-                a[x[0] as usize][1]
-                    + a[x[1] as usize][1]
-                    + a[x[2] as usize][1]
-                    + a[x[3] as usize][1]
-                    + a[x[4] as usize][1]
-                    + a[x[5] as usize][1]
-                    + a[x[6] as usize][1]
-                    + a[x[7] as usize][1]
-                    + a[x[8] as usize][1]
-                    + a[x[9] as usize][1],
-            ])
+            [
+                a[x[0] as usize][0] + a[x[1] as usize][0] + a[x[2] as usize][0],
+                a[x[0] as usize][1] + a[x[1] as usize][1] + a[x[2] as usize][1],
+            ]
         );
     }
 }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 168 - 103 - 197  [0.569] 468
...      dev playing White: 98 - 45 - 91  [0.613] 234
...      dev playing Black: 70 - 58 - 106  [0.526] 234
...      White vs Black: 156 - 115 - 197  [0.544] 468
Elo difference: 48.6 +/- 24.0, LOS: 100.0 %, DrawRatio: 42.1 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            91       6    9000    4381    2085    2534   5648.0   62.8%   28.2%
   1 Monolith-2                    -85      11    3000     711    1433     856   1139.0   38.0%   28.5%
   2 Wahoo_v4                      -90      11    3000     690    1452     858   1119.0   37.3%   28.6%
   3 Vajolet2_2.8                  -96      11    3000     684    1496     820   1094.0   36.5%   27.3%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     65     56     56     64     65     51     51     45     50     59     43     50     55     54     48    812
   Score   7476   6838   7102   7684   7566   7573   6708   6445   5888   7044   6032   6367   6615   6746   6381 102465
Score(%)   88.0   85.5   82.6   86.3   89.0   94.7   81.8   80.6   82.9   89.2   86.2   86.0   88.2   85.4   87.4   86.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.7%, "Re-Capturing"
2. STS 10, 89.2%, "Simplification"
3. STS 05, 89.0%, "Bishop vs Knight"
4. STS 13, 88.2%, "Pawn Play in the Center"
5. STS 01, 88.0%, "Undermining"

:: Top 5 STS with low result ::
1. STS 08, 80.6%, "Advancement of f/g/h Pawns"
2. STS 07, 81.8%, "Offer of Simplification"
3. STS 03, 82.6%, "Knight Outposts"
4. STS 09, 82.9%, "Advancement of a/b/c Pawns"
5. STS 14, 85.4%, "Queens and Rooks to the 7th rank"
```