### PR TITLE
Optimize

### DIFF
--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -59,9 +59,9 @@ impl From<Square> for Bitboard {
 }
 
 /// An iterator over the [`Square`]s in a [`Bitboard`].
-pub struct BitboardIter(sm::bitboard::IntoIter);
+pub struct Iter(sm::bitboard::IntoIter);
 
-impl Iterator for BitboardIter {
+impl Iterator for Iter {
     type Item = Square;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -69,12 +69,18 @@ impl Iterator for BitboardIter {
     }
 }
 
+impl ExactSizeIterator for Iter {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
 impl IntoIterator for Bitboard {
     type Item = Square;
-    type IntoIter = BitboardIter;
+    type IntoIter = Iter;
 
     fn into_iter(self) -> Self::IntoIter {
-        BitboardIter(self.0.into_iter())
+        Iter(self.0.into_iter())
     }
 }
 

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -2,7 +2,7 @@ use derive_more::Display;
 use shakmaty as sm;
 use std::ops::Not;
 
-/// Denotes the color of a chess [`Piece`][`crate::Piece`].
+/// The color of a chess [`Piece`][`crate::Piece`].
 #[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -2,7 +2,7 @@ use derive_more::Display;
 use shakmaty as sm;
 use std::ops::Sub;
 
-/// Denotes a column on the chess board.
+/// A column on the chess board.
 #[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
@@ -87,6 +87,7 @@ impl From<File> for sm::File {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::Buffer;
     use std::mem::size_of;
     use test_strategy::proptest;
 
@@ -96,39 +97,8 @@ mod tests {
     }
 
     #[proptest]
-    fn iter_returns_iterator_over_files_in_order() {
-        assert_eq!(
-            File::iter().collect::<Vec<_>>(),
-            (0..=7).map(File::from_index).collect::<Vec<_>>()
-        );
-    }
-
-    #[proptest]
-    fn iter_returns_double_ended_iterator() {
-        assert_eq!(
-            File::iter().rev().collect::<Vec<_>>(),
-            (0..=7).rev().map(File::from_index).collect::<Vec<_>>()
-        );
-    }
-
-    #[proptest]
-    fn iter_returns_iterator_of_exact_size() {
-        assert_eq!(File::iter().len(), 8);
-    }
-
-    #[proptest]
     fn file_has_an_index(f: File) {
         assert_eq!(File::from_index(f.index()), f);
-    }
-
-    #[proptest]
-    fn file_has_a_mirror(f: File) {
-        assert_eq!(f.mirror().index(), 7 - f.index());
-    }
-
-    #[proptest]
-    fn subtracting_files_gives_distance(a: File, b: File) {
-        assert_eq!(a - b, a.index() as i8 - b.index() as i8);
     }
 
     #[proptest]
@@ -147,6 +117,37 @@ mod tests {
     #[proptest]
     fn file_is_ordered_by_index(a: File, b: File) {
         assert_eq!(a < b, a.index() < b.index());
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_over_files_in_order() {
+        assert_eq!(
+            File::iter().collect::<Buffer<_, 8>>(),
+            (0..=7).map(File::from_index).collect()
+        );
+    }
+
+    #[proptest]
+    fn iter_returns_double_ended_iterator() {
+        assert_eq!(
+            File::iter().rev().collect::<Buffer<_, 8>>(),
+            (0..=7).rev().map(File::from_index).collect()
+        );
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_of_exact_size() {
+        assert_eq!(File::iter().len(), 8);
+    }
+
+    #[proptest]
+    fn file_has_a_mirror(f: File) {
+        assert_eq!(f.mirror().index(), 7 - f.index());
+    }
+
+    #[proptest]
+    fn subtracting_files_gives_distance(a: File, b: File) {
+        assert_eq!(a - b, a.index() as i8 - b.index() as i8);
     }
 
     #[proptest]

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -317,9 +317,8 @@ impl Position {
         let turn = self.turn();
         let attackers = self.attackers(whither, turn);
 
-        use Role::*;
         if !attackers.is_empty() {
-            for role in [Pawn, Knight, Bishop, Rook, Queen, King] {
+            for role in Role::iter() {
                 if self.by_piece(Piece(turn, role)) & attackers != Bitboard::empty() {
                     let moves = sm::Position::san_candidates(&self.0, role.into(), whither.into());
                     if let Some(vm) = moves.into_iter().max_by_key(|vm| vm.promotion()) {

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -2,7 +2,7 @@ use derive_more::Display;
 use shakmaty as sm;
 use std::ops::Sub;
 
-/// Denotes a row on the chess board.
+/// A row on the chess board.
 #[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
@@ -87,6 +87,7 @@ impl From<Rank> for sm::Rank {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::Buffer;
     use std::mem::size_of;
     use test_strategy::proptest;
 
@@ -96,39 +97,8 @@ mod tests {
     }
 
     #[proptest]
-    fn iter_returns_iterator_over_ranks_in_order() {
-        assert_eq!(
-            Rank::iter().collect::<Vec<_>>(),
-            (0..=7).map(Rank::from_index).collect::<Vec<_>>()
-        );
-    }
-
-    #[proptest]
-    fn iter_returns_double_ended_iterator() {
-        assert_eq!(
-            Rank::iter().rev().collect::<Vec<_>>(),
-            (0..=7).rev().map(Rank::from_index).collect::<Vec<_>>()
-        );
-    }
-
-    #[proptest]
-    fn iter_returns_iterator_of_exact_size() {
-        assert_eq!(Rank::iter().len(), 8);
-    }
-
-    #[proptest]
     fn rank_has_an_index(r: Rank) {
         assert_eq!(Rank::from_index(r.index()), r);
-    }
-
-    #[proptest]
-    fn rank_has_a_mirror(r: Rank) {
-        assert_eq!(r.mirror().index(), 7 - r.index());
-    }
-
-    #[proptest]
-    fn subtracting_ranks_gives_distance(a: Rank, b: Rank) {
-        assert_eq!(a - b, a.index() as i8 - b.index() as i8);
     }
 
     #[proptest]
@@ -147,6 +117,37 @@ mod tests {
     #[proptest]
     fn rank_is_ordered_by_index(a: Rank, b: Rank) {
         assert_eq!(a < b, a.index() < b.index());
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_over_ranks_in_order() {
+        assert_eq!(
+            Rank::iter().collect::<Buffer<_, 8>>(),
+            (0..=7).map(Rank::from_index).collect()
+        );
+    }
+
+    #[proptest]
+    fn iter_returns_double_ended_iterator() {
+        assert_eq!(
+            Rank::iter().rev().collect::<Buffer<_, 8>>(),
+            (0..=7).rev().map(Rank::from_index).collect()
+        );
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_of_exact_size() {
+        assert_eq!(Rank::iter().len(), 8);
+    }
+
+    #[proptest]
+    fn rank_has_a_mirror(r: Rank) {
+        assert_eq!(r.mirror().index(), 7 - r.index());
+    }
+
+    #[proptest]
+    fn subtracting_ranks_gives_distance(a: Rank, b: Rank) {
+        assert_eq!(a - b, a.index() as i8 - b.index() as i8);
     }
 
     #[proptest]

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -2,7 +2,7 @@ use derive_more::Display;
 use shakmaty as sm;
 use vampirc_uci::UciPiece;
 
-/// Denotes the type of a chess [`Piece`][`crate::Piece`].
+/// The type of a chess [`Piece`][`crate::Piece`].
 #[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
@@ -19,6 +19,36 @@ pub enum Role {
     Queen,
     #[display(fmt = "k")]
     King,
+}
+
+impl Role {
+    const ROLES: [Self; 6] = [
+        Role::Pawn,
+        Role::Knight,
+        Role::Bishop,
+        Role::Rook,
+        Role::Queen,
+        Role::King,
+    ];
+
+    /// Constructs [`Role`] from index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is not in the range (0..=5).
+    pub fn from_index(i: u8) -> Self {
+        Self::ROLES[i as usize]
+    }
+
+    /// This role's index in the range (0..=5).
+    pub fn index(&self) -> u8 {
+        *self as _
+    }
+
+    /// Returns an iterator over [`Role`]s ordered by [index][`Role::index`].
+    pub fn iter() -> impl DoubleEndedIterator<Item = Self> + ExactSizeIterator {
+        Self::ROLES.into_iter()
+    }
 }
 
 #[doc(hidden)]
@@ -80,11 +110,61 @@ impl From<sm::Role> for Role {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::Buffer;
+    use std::mem::size_of;
     use test_strategy::proptest;
 
     #[proptest]
+    fn role_guarantees_zero_value_optimization() {
+        assert_eq!(size_of::<Option<Role>>(), size_of::<Role>());
+    }
+
+    #[proptest]
+    fn role_has_an_index(r: Role) {
+        assert_eq!(Role::from_index(r.index()), r);
+    }
+
+    #[proptest]
+
+    fn from_index_constructs_role_by_index(#[strategy(0u8..6)] i: u8) {
+        assert_eq!(Role::from_index(i).index(), i);
+    }
+
+    #[proptest]
+    #[should_panic]
+
+    fn from_index_panics_if_index_out_of_range(#[strategy(6u8..)] i: u8) {
+        Role::from_index(i);
+    }
+
+    #[proptest]
+    fn role_is_ordered_by_index(a: Role, b: Role) {
+        assert_eq!(a < b, a.index() < b.index());
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_over_roles_in_order() {
+        assert_eq!(
+            Role::iter().collect::<Buffer<_, 6>>(),
+            (0..6).map(Role::from_index).collect()
+        );
+    }
+    #[proptest]
+    fn iter_returns_double_ended_iterator() {
+        assert_eq!(
+            Role::iter().rev().collect::<Buffer<_, 6>>(),
+            (0..6).rev().map(Role::from_index).collect()
+        );
+    }
+
+    #[proptest]
+    fn iter_returns_iterator_of_exact_size() {
+        assert_eq!(Role::iter().len(), 6);
+    }
+
+    #[proptest]
     fn role_has_an_equivalent_uci_representation(r: Role) {
-        assert_eq!(Role::from(<UciPiece as From<Role>>::from(r)), r);
+        assert_eq!(Role::from(UciPiece::from(r)), r);
     }
 
     #[proptest]

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -1,5 +1,4 @@
-use crate::chess::{Color, Move, Piece, Position, Role, Square};
-use crate::chess::{ImpossibleExchange, ImpossiblePass};
+use crate::chess::{Color, ImpossibleExchange, Move, Piece, Position, Role, Square};
 use crate::nnue::{Accumulator, Feature, Material, Positional};
 use crate::util::Assume;
 use crate::{search::Value, util::Buffer};
@@ -88,13 +87,12 @@ impl<T: Clone + Accumulator> Evaluator<T> {
         }
     }
 
-    /// Play a [null-move] if legal in this position.
+    /// Play a [null-move].
     ///
     /// [null-move]: https://www.chessprogramming.org/Null_Move
-    pub fn pass(&mut self) -> Result<(), ImpossiblePass> {
-        self.pos.pass()?;
+    pub fn pass(&mut self) {
+        self.pos.pass();
         self.acc.mirror();
-        Ok(())
     }
 
     /// Play a [`Move`].
@@ -170,9 +168,10 @@ mod tests {
     }
 
     #[proptest]
-    fn pass_updates_accumulator(#[filter(#a.clone().pass().is_ok())] mut a: Evaluator) {
+    fn pass_updates_accumulator(#[filter(!#a.is_check())] mut a: Evaluator) {
         let mut b = a.pos.clone();
-        assert_eq!(a.pass(), b.pass());
+        a.pass();
+        b.pass();
         assert_eq!(a, Evaluator::new(b));
     }
 

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -1,5 +1,5 @@
 use crate::chess::{Color, Move, Piece, Position, Role, Square};
-use crate::chess::{IllegalMove, ImpossibleExchange, ImpossiblePass};
+use crate::chess::{ImpossibleExchange, ImpossiblePass};
 use crate::nnue::{Accumulator, Feature, Material, Positional};
 use crate::util::Assume;
 use crate::{search::Value, util::Buffer};
@@ -97,13 +97,12 @@ impl<T: Clone + Accumulator> Evaluator<T> {
         Ok(())
     }
 
-    /// Play a [`Move`] if legal in this position.
-    pub fn play(&mut self, m: Move) -> Result<Move, IllegalMove> {
+    /// Play a [`Move`].
+    pub fn play(&mut self, m: Move) {
         let capture = self.role_on(m.whither());
-        let m = self.pos.play(m)?;
+        self.pos.play(m);
         self.acc.mirror();
         self.update(m, capture);
-        Ok(m)
     }
 
     /// Exchange a piece on [`Square`] by the attacker of least value.
@@ -165,7 +164,8 @@ mod tests {
         #[map(|s: Selector| s.select(#a.moves()))] m: Move,
     ) {
         let mut b = a.pos.clone();
-        assert_eq!(a.play(m), b.play(m));
+        a.play(m);
+        b.play(m);
         assert_eq!(a, Evaluator::new(b));
     }
 

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -153,7 +153,7 @@ impl<T: Clone + Accumulator> Evaluator<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proptest::{prop_assume, sample::Selector};
+    use proptest::sample::Selector;
     use test_strategy::proptest;
 
     #[proptest]
@@ -176,16 +176,16 @@ mod tests {
     }
 
     #[proptest]
-    fn exchange_updates_accumulator(
-        #[filter(#a.moves().filter(Move::is_capture).next().is_some())] mut a: Evaluator,
-        #[map(|s: Selector| s.select(#a.moves().filter(Move::is_capture)))] m: Move,
+    fn exchange_updates_evaluator(
+        #[by_ref]
+        #[filter(#a.moves().filter(|m| m.is_capture() && !m.is_en_passant()).next().is_some())]
+        mut a: Evaluator,
+        #[map(|s: Selector| s.select(#a.moves().filter(|m| m.is_capture() && !m.is_en_passant())).whither())]
+        s: Square,
     ) {
         let mut b = a.pos.clone();
-
-        // Skip en passant captures.
-        prop_assume!(b.exchange(m.whither()).is_ok());
-
-        a.exchange(m.whither())?;
+        a.exchange(s)?;
+        b.exchange(s)?;
         assert_eq!(a, Evaluator::new(b));
     }
 }

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -214,7 +214,7 @@ impl Engine {
         } else if !is_pv && !in_check {
             if let Some(d) = self.nmp(pos, score, beta, depth) {
                 let mut next = pos.clone();
-                next.pass().assume();
+                next.pass();
                 if d <= ply || -self.nw(&next, -beta + 1, d, ply + 1, ctrl)? >= beta {
                     #[cfg(not(test))]
                     // The null move pruning heuristic is not exact.

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -232,7 +232,7 @@ impl Engine {
 
             let mut next = pos.material();
             let material = next.evaluate();
-            next.play(m).assume();
+            next.play(m);
             let see = -next.see(m.whither());
 
             let gain = if Self::KILLERS.with_borrow(|ks| ks.contains(ply, pos.turn(), m)) {
@@ -250,7 +250,7 @@ impl Engine {
             None => return Ok(Pv::new(score, [])),
             Some((m, _)) => {
                 let mut next = pos.clone();
-                next.play(m).assume();
+                next.play(m);
                 let mut pv = -self.ns(&next, -beta..-alpha, depth, ply + 1, ctrl)?;
                 pv.shift(m);
 
@@ -281,7 +281,7 @@ impl Engine {
                 }
 
                 let mut next = pos.clone();
-                next.play(m).assume();
+                next.play(m);
 
                 if !in_check && gain < 60 {
                     let guess = -next.clone().see(m.whither()).cast();
@@ -417,7 +417,7 @@ mod tests {
             .filter(|m| ply < depth || pos.is_check() || !m.is_quiet())
             .map(|m| {
                 let mut next = pos.clone();
-                next.play(m).unwrap();
+                next.play(m);
                 -negamax(&next, depth, ply + 1)
             })
             .max()

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -12,7 +12,7 @@ pub struct Pv {
     #[deref]
     #[deref_mut]
     #[into_iterator]
-    line: Buffer<Move, 15>,
+    line: Buffer<Move, 12>,
 }
 
 impl Pv {
@@ -76,7 +76,13 @@ impl Neg for Pv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::mem::size_of;
     use test_strategy::proptest;
+
+    #[proptest]
+    fn size_of_pv_is_at_most_32_bytes() {
+        assert!(size_of::<Pv>() <= 32);
+    }
 
     #[proptest]
     fn score_returns_score(pv: Pv) {

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -1,7 +1,6 @@
 use crate::chess::{Color, Position};
-use crate::nnue::Evaluator;
 use crate::search::{Depth, Engine, HashSize, Limits, Options, ThreadCount};
-use crate::util::{Assume, Io};
+use crate::{nnue::Evaluator, util::Io};
 use std::io::{self, stdin, stdout, Stdin, Stdout};
 use std::{num::NonZeroUsize, ops::Shr, time::Duration};
 use vampirc_uci::{self as uci, *};
@@ -86,7 +85,7 @@ impl Uci {
             return error!("illegal move `{uci}` in position `{}`", self.position);
         };
 
-        self.position.play(m).assume();
+        self.position.play(m);
         self.moves.push(uci);
     }
 
@@ -415,7 +414,7 @@ mod tests {
         };
 
         uci.play(m.into());
-        assert_eq!(pos.play(m), Ok(m));
+        pos.play(m);
         assert_eq!(uci.position, pos);
     }
 

--- a/lib/util/assume.rs
+++ b/lib/util/assume.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 /// A trait for types that can be assumed to be another type.
 pub trait Assume {
     /// The type of the assumed value.
@@ -10,17 +12,33 @@ pub trait Assume {
 impl<T> Assume for Option<T> {
     type Assumed = T;
 
+    #[inline]
+    #[track_caller]
     fn assume(self) -> Self::Assumed {
-        // Definitely not safe, but we'll do it anyway.
-        unsafe { self.unwrap_unchecked() }
+        #[cfg(not(test))]
+        unsafe {
+            // Definitely not safe, but we'll assume unit tests will catch everything.
+            self.unwrap_unchecked()
+        }
+
+        #[cfg(test)]
+        self.unwrap()
     }
 }
 
-impl<T, E> Assume for Result<T, E> {
+impl<T, E: Debug> Assume for Result<T, E> {
     type Assumed = T;
 
+    #[inline]
+    #[track_caller]
     fn assume(self) -> Self::Assumed {
-        // Definitely not safe, but we'll do it anyway.
-        unsafe { self.unwrap_unchecked() }
+        #[cfg(not(test))]
+        unsafe {
+            // Definitely not safe, but we'll assume unit tests will catch everything.
+            self.unwrap_unchecked()
+        }
+
+        #[cfg(test)]
+        self.unwrap()
     }
 }

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -11,7 +11,7 @@ fn perft(pos: &Position, depth: u8) -> usize {
             .par_bridge()
             .map(|m| {
                 let mut next = pos.clone();
-                next.play(m).expect("expected legal move");
+                next.play(m);
                 perft(&next, d - 1)
             })
             .sum(),


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Vajolet2_2.8 -engine conf=Monolith-2 -engine conf=Wahoo_v4 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            99       6    9000    4455    1966    2579   5744.5   63.8%   28.7%
   1 Monolith-2                    -94      11    3000     684    1473     843   1105.5   36.9%   28.1%
   2 Wahoo_v4                     -100      11    3000     637    1475     888   1081.0   36.0%   29.6%
   3 Vajolet2_2.8                 -103      11    3000     645    1507     848   1069.0   35.6%   28.3%
```

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Nalwald-18 -engine conf=Counter-5.0 -engine conf=StockNemo-5.7 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                           -29       6    9000    2546    3286    3168   4130.0   45.9%   35.2%
   1 Nalwald-18                     57      10    3000    1176     691    1133   1742.5   58.1%   37.8%
   2 Counter-5.0                    37      10    3000    1181     862     957   1659.5   55.3%   31.9%
   3 StockNemo-5.7                  -7      10    3000     929     993    1078   1468.0   48.9%   35.9%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     53     59     68     62     50     56     47     50     57     43     51     57     54     44    817
   Score   7577   6623   7232   7981   7534   7547   6818   6410   5865   7040   5871   6567   6802   6631   6269 102767
Score(%)   89.1   82.8   84.1   89.7   88.6   94.3   83.1   80.1   82.6   89.1   83.9   88.7   90.7   83.9   85.9   86.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.3%, "Re-Capturing"
2. STS 13, 90.7%, "Pawn Play in the Center"
3. STS 04, 89.7%, "Square Vacancy"
4. STS 01, 89.1%, "Undermining"
5. STS 10, 89.1%, "Simplification"

:: Top 5 STS with low result ::
1. STS 08, 80.1%, "Advancement of f/g/h Pawns"
2. STS 09, 82.6%, "Advancement of a/b/c Pawns"
3. STS 02, 82.8%, "Open Files and Diagonals"
4. STS 07, 83.1%, "Offer of Simplification"
5. STS 11, 83.9%, "Activity of the King"
```