### PR TITLE
Migrate from shakmaty to cozy-chess for move generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,13 +115,13 @@ dependencies = [
  "atomic",
  "bytemuck",
  "clap",
+ "cozy-chess",
  "criterion",
  "derive_more",
  "num-traits",
  "num_cpus",
  "proptest",
  "rayon",
- "shakmaty",
  "test-strategy",
  "vampirc-uci",
 ]
@@ -220,6 +211,21 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cozy-chess"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bdd7bb0b9929ea783edc2457cdd9d5b4d9732581359d33ef71224c865208cf"
+dependencies = [
+ "cozy-chess-types",
+]
+
+[[package]]
+name = "cozy-chess-types"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4a557c6659b8705d301732f473c9a61659c740ffda3e3485e79d1d4b7a1e12"
 
 [[package]]
 name = "cpufeatures"
@@ -777,17 +783,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "shakmaty"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da274d26b6aac011b0af8ec3514eb1d598cf51fb47944d1d2142338f210cfb3"
-dependencies = [
- "arrayvec",
- "bitflags",
- "btoi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.4.7", default-features = false, features = [
     "suggestions",
     "usage",
 ] }
+cozy-chess = { version = "0.3.3", default-features = false, features = ["std"] }
 derive_more = { version = "0.99.16", default-features = false, features = [
     "add",
     "add_assign",
@@ -34,8 +35,12 @@ derive_more = { version = "0.99.16", default-features = false, features = [
 ] }
 num-traits = { version = "0.2.17", default-features = false, features = ["std"] }
 rayon = { version = "1.8.0", default-features = false }
-shakmaty = { version = "0.26.0", default-features = false, features = ["std"] }
 vampirc-uci = { version = "0.11.0", default-features = false }
+
+[target.'cfg(all(target_arch = "x86", target_feature = "bmi2"))'.dependencies.cozy-chess]
+version = "0.3.3"
+default-features = false
+features = ["pext"]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = ["rayon"] }

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -1,5 +1,5 @@
+use cozy_chess as cc;
 use derive_more::Display;
-use shakmaty as sm;
 use std::ops::Not;
 
 /// The color of a chess [`Piece`][`crate::Piece`].
@@ -25,21 +25,21 @@ impl Not for Color {
 }
 
 #[doc(hidden)]
-impl From<sm::Color> for Color {
-    fn from(c: sm::Color) -> Self {
+impl From<cc::Color> for Color {
+    fn from(c: cc::Color) -> Self {
         match c {
-            sm::Color::White => Color::White,
-            sm::Color::Black => Color::Black,
+            cc::Color::White => Color::White,
+            cc::Color::Black => Color::Black,
         }
     }
 }
 
 #[doc(hidden)]
-impl From<Color> for sm::Color {
+impl From<Color> for cc::Color {
     fn from(c: Color) -> Self {
         match c {
-            Color::White => sm::Color::White,
-            Color::Black => sm::Color::Black,
+            Color::White => cc::Color::White,
+            Color::Black => cc::Color::Black,
         }
     }
 }
@@ -55,7 +55,7 @@ mod tests {
     }
 
     #[proptest]
-    fn color_has_an_equivalent_shakmaty_representation(c: Color) {
-        assert_eq!(Color::from(sm::Color::from(c)), c);
+    fn color_has_an_equivalent_cozy_chess_representation(c: Color) {
+        assert_eq!(Color::from(cc::Color::from(c)), c);
     }
 }

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -1,5 +1,5 @@
+use cozy_chess as cc;
 use derive_more::Display;
-use shakmaty as sm;
 use std::ops::Sub;
 
 /// A column on the chess board.
@@ -71,16 +71,16 @@ impl Sub for File {
 }
 
 #[doc(hidden)]
-impl From<sm::File> for File {
-    fn from(f: sm::File) -> Self {
+impl From<cc::File> for File {
+    fn from(f: cc::File) -> Self {
         File::from_index(f as _)
     }
 }
 
 #[doc(hidden)]
-impl From<File> for sm::File {
+impl From<File> for cc::File {
     fn from(f: File) -> Self {
-        sm::File::new(f as _)
+        cc::File::index_const(f as _)
     }
 }
 
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[proptest]
-    fn file_has_an_equivalent_shakmaty_representation(f: File) {
-        assert_eq!(File::from(sm::File::from(f)), f);
+    fn file_has_an_equivalent_cozy_chess_representation(f: File) {
+        assert_eq!(File::from(cc::File::from(f)), f);
     }
 }

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -1,5 +1,4 @@
 use crate::chess::{Color, Role};
-use shakmaty as sm;
 
 /// A chess [piece][`Role`] of a certain [`Color`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -28,23 +27,6 @@ impl Piece {
     }
 }
 
-#[doc(hidden)]
-impl From<sm::Piece> for Piece {
-    fn from(p: sm::Piece) -> Self {
-        Piece(p.color.into(), p.role.into())
-    }
-}
-
-#[doc(hidden)]
-impl From<Piece> for sm::Piece {
-    fn from(p: Piece) -> Self {
-        sm::Piece {
-            color: p.color().into(),
-            role: p.role().into(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,10 +51,5 @@ mod tests {
     fn piece_has_a_mirror_of_the_same_role_and_opposite_color(p: Piece) {
         assert_eq!(p.mirror().role(), p.role());
         assert_eq!(p.mirror().color(), !p.color());
-    }
-
-    #[proptest]
-    fn piece_has_an_equivalent_shakmaty_representation(p: Piece) {
-        assert_eq!(Piece::from(sm::Piece::from(p)), p);
     }
 }

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -1,5 +1,5 @@
+use cozy_chess as cc;
 use derive_more::Display;
-use shakmaty as sm;
 use std::ops::Sub;
 
 /// A row on the chess board.
@@ -71,16 +71,16 @@ impl Sub for Rank {
 }
 
 #[doc(hidden)]
-impl From<sm::Rank> for Rank {
-    fn from(r: sm::Rank) -> Self {
+impl From<cc::Rank> for Rank {
+    fn from(r: cc::Rank) -> Self {
         Rank::from_index(r as _)
     }
 }
 
 #[doc(hidden)]
-impl From<Rank> for sm::Rank {
+impl From<Rank> for cc::Rank {
     fn from(r: Rank) -> Self {
-        sm::Rank::new(r as _)
+        cc::Rank::index_const(r as _)
     }
 }
 
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[proptest]
-    fn rank_has_an_equivalent_shakmaty_representation(r: Rank) {
-        assert_eq!(Rank::from(sm::Rank::from(r)), r);
+    fn rank_has_an_equivalent_cozy_chess_representation(r: Rank) {
+        assert_eq!(Rank::from(cc::Rank::from(r)), r);
     }
 }

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -1,5 +1,5 @@
+use cozy_chess as cc;
 use derive_more::Display;
-use shakmaty as sm;
 use vampirc_uci::UciPiece;
 
 /// The type of a chess [`Piece`][`crate::Piece`].
@@ -80,30 +80,16 @@ impl From<UciPiece> for Role {
 }
 
 #[doc(hidden)]
-impl From<Role> for sm::Role {
+impl From<Role> for cc::Piece {
     fn from(r: Role) -> Self {
-        match r {
-            Role::Pawn => sm::Role::Pawn,
-            Role::Knight => sm::Role::Knight,
-            Role::Bishop => sm::Role::Bishop,
-            Role::Rook => sm::Role::Rook,
-            Role::Queen => sm::Role::Queen,
-            Role::King => sm::Role::King,
-        }
+        cc::Piece::index_const(r as _)
     }
 }
 
 #[doc(hidden)]
-impl From<sm::Role> for Role {
-    fn from(r: sm::Role) -> Self {
-        match r {
-            sm::Role::Pawn => Role::Pawn,
-            sm::Role::Knight => Role::Knight,
-            sm::Role::Bishop => Role::Bishop,
-            sm::Role::Rook => Role::Rook,
-            sm::Role::Queen => Role::Queen,
-            sm::Role::King => Role::King,
-        }
+impl From<cc::Piece> for Role {
+    fn from(r: cc::Piece) -> Self {
+        Role::from_index(r as _)
     }
 }
 
@@ -168,7 +154,7 @@ mod tests {
     }
 
     #[proptest]
-    fn role_has_an_equivalent_shakmaty_representation(r: Role) {
-        assert_eq!(Role::from(sm::Role::from(r)), r);
+    fn role_has_an_equivalent_cozy_chess_representation(r: Role) {
+        assert_eq!(Role::from(cc::Piece::from(r)), r);
     }
 }

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -1,6 +1,6 @@
 use crate::chess::{File, Rank};
 use crate::util::{Binary, Bits};
-use shakmaty as sm;
+use cozy_chess as cc;
 use std::{convert::Infallible, fmt, ops::Sub};
 use vampirc_uci::UciSquare;
 
@@ -123,16 +123,16 @@ impl From<UciSquare> for Square {
 }
 
 #[doc(hidden)]
-impl From<sm::Square> for Square {
-    fn from(s: sm::Square) -> Self {
+impl From<cc::Square> for Square {
+    fn from(s: cc::Square) -> Self {
         Square::from_index(s as _)
     }
 }
 
 #[doc(hidden)]
-impl From<Square> for sm::Square {
+impl From<Square> for cc::Square {
     fn from(s: Square) -> Self {
-        sm::Square::new(s as _)
+        cc::Square::index_const(s as _)
     }
 }
 
@@ -223,7 +223,7 @@ mod tests {
     }
 
     #[proptest]
-    fn square_has_an_equivalent_shakmaty_representation(s: Square) {
-        assert_eq!(Square::from(sm::Square::from(s)), s);
+    fn square_has_an_equivalent_cozy_chess_representation(s: Square) {
+        assert_eq!(Square::from(cc::Square::from(s)), s);
     }
 }

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -26,7 +26,7 @@ pub struct Evaluator<T: Clone + Accumulator = (Material, Positional)> {
 }
 
 impl Evaluator {
-    /// Constructs the accumulator from a [`Position`].
+    /// Constructs the evaluator from a [`Position`].
     pub fn new(pos: Position) -> Self {
         let mut acc = <(Material, Positional)>::default();
 
@@ -153,13 +153,14 @@ impl<T: Clone + Accumulator> Evaluator<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chess::Bitboard;
     use proptest::sample::Selector;
     use test_strategy::proptest;
 
     #[proptest]
-    fn play_updates_accumulator(
+    fn play_updates_evaluator(
         #[filter(#a.outcome().is_none())] mut a: Evaluator,
-        #[map(|s: Selector| s.select(#a.moves()))] m: Move,
+        #[map(|s: Selector| s.select(#a.moves(Bitboard::full())))] m: Move,
     ) {
         let mut b = a.pos.clone();
         a.play(m);
@@ -168,7 +169,7 @@ mod tests {
     }
 
     #[proptest]
-    fn pass_updates_accumulator(#[filter(!#a.is_check())] mut a: Evaluator) {
+    fn pass_updates_evaluator(#[filter(!#a.is_check())] mut a: Evaluator) {
         let mut b = a.pos.clone();
         a.pass();
         b.pass();
@@ -178,9 +179,9 @@ mod tests {
     #[proptest]
     fn exchange_updates_evaluator(
         #[by_ref]
-        #[filter(#a.moves().filter(|m| m.is_capture() && !m.is_en_passant()).next().is_some())]
+        #[filter(#a.moves(Bitboard::full()).filter(|m| m.is_capture() && !m.is_en_passant()).next().is_some())]
         mut a: Evaluator,
-        #[map(|s: Selector| s.select(#a.moves().filter(|m| m.is_capture() && !m.is_en_passant())).whither())]
+        #[map(|s: Selector| s.select(#a.moves(Bitboard::full()).filter(|m| m.is_capture() && !m.is_en_passant())).whither())]
         s: Square,
     ) {
         let mut b = a.pos.clone();

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -18,6 +18,7 @@ fn perft(pos: &Position, depth: u8) -> usize {
     }
 }
 
+#[cfg(not(tarpaulin))]
 #[proptest(cases = 1)]
 fn perft_expands_expected_number_of_nodes() {
     // https://www.chessprogramming.org/Perft_Results#Initial_Position

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -1,13 +1,13 @@
-use lib::chess::Position;
+use lib::chess::{Bitboard, Position};
 use rayon::prelude::*;
 use test_strategy::proptest;
 
 fn perft(pos: &Position, depth: u8) -> usize {
     match depth {
         0 => 1,
-        1 => pos.moves().len(),
+        1 => pos.moves(Bitboard::full()).count(),
         d => pos
-            .moves()
+            .moves(Bitboard::full())
             .par_bridge()
             .map(|m| {
                 let mut next = pos.clone();


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Nalwald-18 -engine conf=Counter-5.0 -engine conf=StockNemo-5.7 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            -9       6    9000    2718    2957    3325   4380.5   48.7%   36.9%
   1 Nalwald-18                     38      10    3000    1057     726    1217   1665.5   55.5%   40.6%
   2 Counter-5.0                    11      10    3000    1043     947    1010   1548.0   51.6%   33.7%
   3 StockNemo-5.7                 -22      10    3000     857    1045    1098   1406.0   46.9%   36.6%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     60     55     59     67     63     48     59     49     47     56     39     55     56     49     47    809
   Score   7292   6566   7187   7797   7563   7503   7285   6716   5639   6860   5780   6704   6790   6523   6349 102554
Score(%)   85.8   82.1   83.6   87.6   89.0   93.8   88.8   84.0   79.4   86.8   82.6   90.6   90.5   82.6   87.0   86.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 93.8%, "Re-Capturing"
2. STS 12, 90.6%, "Center Control"
3. STS 13, 90.5%, "Pawn Play in the Center"
4. STS 05, 89.0%, "Bishop vs Knight"
5. STS 07, 88.8%, "Offer of Simplification"

:: Top 5 STS with low result ::
1. STS 09, 79.4%, "Advancement of a/b/c Pawns"
2. STS 02, 82.1%, "Open Files and Diagonals"
3. STS 14, 82.6%, "Queens and Rooks to the 7th rank"
4. STS 11, 82.6%, "Activity of the King"
5. STS 03, 83.6%, "Knight Outposts"

```