### PR TITLE
Inline

### DIFF
--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -96,6 +96,7 @@ impl IntoIterator for Bitboard {
 
 #[doc(hidden)]
 impl From<cc::BitBoard> for Bitboard {
+    #[inline(always)]
     fn from(bb: cc::BitBoard) -> Self {
         Bitboard(bb)
     }
@@ -103,6 +104,7 @@ impl From<cc::BitBoard> for Bitboard {
 
 #[doc(hidden)]
 impl From<Bitboard> for cc::BitBoard {
+    #[inline(always)]
     fn from(bb: Bitboard) -> Self {
         bb.0
     }

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -26,6 +26,7 @@ impl Not for Color {
 
 #[doc(hidden)]
 impl From<cc::Color> for Color {
+    #[inline(always)]
     fn from(c: cc::Color) -> Self {
         match c {
             cc::Color::White => Color::White,
@@ -36,6 +37,7 @@ impl From<cc::Color> for Color {
 
 #[doc(hidden)]
 impl From<Color> for cc::Color {
+    #[inline(always)]
     fn from(c: Color) -> Self {
         match c {
             Color::White => cc::Color::White,

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -72,6 +72,7 @@ impl Sub for File {
 
 #[doc(hidden)]
 impl From<cc::File> for File {
+    #[inline(always)]
     fn from(f: cc::File) -> Self {
         File::from_index(f as _)
     }
@@ -79,6 +80,7 @@ impl From<cc::File> for File {
 
 #[doc(hidden)]
 impl From<File> for cc::File {
+    #[inline(always)]
     fn from(f: File) -> Self {
         cc::File::index_const(f as _)
     }

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -10,11 +10,13 @@ use vampirc_uci::UciMove;
 pub struct Move(NonZeroU16);
 
 impl Move {
+    #[inline(always)]
     fn bits<R: RangeBounds<u32>>(&self, r: R) -> Bits<u16, 16> {
         Bits::new(self.0.get()).slice(r)
     }
 
     /// Constructs a castling move.
+    #[inline(always)]
     pub fn castling(whence: Square, whither: Square) -> Self {
         let mut bits = Bits::<_, 16>::default();
         bits.push(whence.encode());
@@ -24,6 +26,7 @@ impl Move {
     }
 
     /// Constructs an en passant move.
+    #[inline(always)]
     pub fn en_passant(whence: Square, whither: Square) -> Self {
         let mut bits = Bits::<_, 16>::default();
         bits.push(whence.encode());
@@ -33,6 +36,7 @@ impl Move {
     }
 
     /// Constructs a regular move.
+    #[inline(always)]
     pub fn regular(
         whence: Square,
         whither: Square,
@@ -57,16 +61,19 @@ impl Move {
     }
 
     /// The source [`Square`].
+    #[inline(always)]
     pub fn whence(&self) -> Square {
         Square::decode(self.bits(10..).pop()).assume()
     }
 
     /// The destination [`Square`].
+    #[inline(always)]
     pub fn whither(&self) -> Square {
         Square::decode(self.bits(4..).pop()).assume()
     }
 
     /// The promotion specifier.
+    #[inline(always)]
     pub fn promotion(&self) -> Option<Role> {
         if self.is_promotion() {
             Some(Role::from_index(self.bits(..2).get() as u8 + 1))
@@ -76,26 +83,31 @@ impl Move {
     }
 
     /// Whether this is a promotion move.
+    #[inline(always)]
     pub fn is_promotion(&self) -> bool {
         self.bits(3..=3).get() != 0
     }
 
     /// Whether this is a castling move.
+    #[inline(always)]
     pub fn is_castling(&self) -> bool {
         self.bits(..4).get() == 0b0001
     }
 
     /// Whether this is an en passant capture move.
+    #[inline(always)]
     pub fn is_en_passant(&self) -> bool {
         self.bits(..4).get() == 0b0011
     }
 
     /// Whether this is a capture move.
+    #[inline(always)]
     pub fn is_capture(&self) -> bool {
         self.bits(2..=2).get() != 0 || (self.bits(1..=1).get() != 0 && !self.is_promotion())
     }
 
     /// Whether this move is neither a capture nor a promotion.
+    #[inline(always)]
     pub fn is_quiet(&self) -> bool {
         !(self.is_capture() || self.is_promotion())
     }

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -72,6 +72,7 @@ impl Sub for Rank {
 
 #[doc(hidden)]
 impl From<cc::Rank> for Rank {
+    #[inline(always)]
     fn from(r: cc::Rank) -> Self {
         Rank::from_index(r as _)
     }
@@ -79,6 +80,7 @@ impl From<cc::Rank> for Rank {
 
 #[doc(hidden)]
 impl From<Rank> for cc::Rank {
+    #[inline(always)]
     fn from(r: Rank) -> Self {
         cc::Rank::index_const(r as _)
     }

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -81,6 +81,7 @@ impl From<UciPiece> for Role {
 
 #[doc(hidden)]
 impl From<Role> for cc::Piece {
+    #[inline(always)]
     fn from(r: Role) -> Self {
         cc::Piece::index_const(r as _)
     }
@@ -88,6 +89,7 @@ impl From<Role> for cc::Piece {
 
 #[doc(hidden)]
 impl From<cc::Piece> for Role {
+    #[inline(always)]
     fn from(r: cc::Piece) -> Self {
         Role::from_index(r as _)
     }

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -124,6 +124,7 @@ impl From<UciSquare> for Square {
 
 #[doc(hidden)]
 impl From<cc::Square> for Square {
+    #[inline(always)]
     fn from(s: cc::Square) -> Self {
         Square::from_index(s as _)
     }
@@ -131,6 +132,7 @@ impl From<cc::Square> for Square {
 
 #[doc(hidden)]
 impl From<Square> for cc::Square {
+    #[inline(always)]
     fn from(s: Square) -> Self {
         cc::Square::index_const(s as _)
     }

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -4,6 +4,7 @@ use std::ops::{AddAssign, SubAssign};
 
 /// A feature transformer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Constructor)]
+#[repr(align(64))]
 pub struct Transformer<T, const I: usize, const O: usize> {
     pub(super) bias: [T; O],
     pub(super) weight: [[T; O]; I],

--- a/lib/util/assume.rs
+++ b/lib/util/assume.rs
@@ -12,7 +12,7 @@ pub trait Assume {
 impl<T> Assume for Option<T> {
     type Assumed = T;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn assume(self) -> Self::Assumed {
         #[cfg(not(test))]
@@ -29,7 +29,7 @@ impl<T> Assume for Option<T> {
 impl<T, E: Debug> Assume for Result<T, E> {
     type Assumed = T;
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     fn assume(self) -> Self::Assumed {
         #[cfg(not(test))]

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -9,6 +9,7 @@ use proptest::prelude::*;
 #[cfg(test)]
 use std::ops::RangeInclusive;
 
+#[inline(always)]
 fn ones<T: PrimInt + Unsigned>(n: u32) -> T {
     match n {
         0 => T::zero(),
@@ -33,17 +34,20 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics if `b` is too wide.
+    #[inline(always)]
     pub fn new(b: T) -> Self {
         assert!(b <= ones(W));
         Bits(b)
     }
 
     /// Get raw collection of bits.
+    #[inline(always)]
     pub fn get(&self) -> T {
         self.0
     }
 
     /// Returns a slice of bits.
+    #[inline(always)]
     pub fn slice<R: RangeBounds<u32>>(&self, r: R) -> Self {
         let a = match r.start_bound() {
             Bound::Included(&i) => i,
@@ -65,6 +69,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics on overflow.
+    #[inline(always)]
     pub fn push<U: 'static + Binary + PrimInt + Unsigned + AsPrimitive<T>, const N: u32>(
         &mut self,
         bits: Bits<U, N>,
@@ -77,6 +82,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics on underflow.
+    #[inline(always)]
     pub fn pop<U: 'static + Binary + PrimInt + Unsigned, const N: u32>(&mut self) -> Bits<U, N>
     where
         T: AsPrimitive<U>,
@@ -88,6 +94,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
 }
 
 impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Default for Bits<T, W> {
+    #[inline(always)]
     fn default() -> Self {
         Bits::new(T::zero())
     }
@@ -96,6 +103,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Default for Bits<T,
 impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Not for Bits<T, W> {
     type Output = Self;
 
+    #[inline(always)]
     fn not(self) -> Self::Output {
         Bits::new(!self.get() & ones(W))
     }

--- a/lib/util/saturating.rs
+++ b/lib/util/saturating.rs
@@ -1,4 +1,4 @@
-use crate::util::Bounds;
+use crate::util::{Assume, Bounds};
 use derive_more::Debug;
 use num_traits::{cast, clamp, AsPrimitive, PrimInt};
 use std::cmp::Ordering;
@@ -31,24 +31,28 @@ impl<T: Bounds> Saturating<T> {
     /// # Panics
     ///
     /// Panics if `i` is outside of the bounds.
+    #[inline(always)]
     pub fn new(i: T::Integer) -> Self {
         assert!((T::LOWER..=T::UPPER).contains(&i));
         Saturating(i)
     }
 
     /// Returns the raw integer.
+    #[inline(always)]
     pub const fn get(&self) -> T::Integer {
         self.0
     }
 
     /// Constructs `Self` from a raw integer through saturation.
+    #[inline(always)]
     pub fn saturate<U: PrimInt>(i: U) -> Self {
         let min = cast(T::LOWER).unwrap_or_else(U::min_value);
         let max = cast(T::UPPER).unwrap_or_else(U::max_value);
-        Saturating::new(cast(clamp(i, min, max)).unwrap())
+        Saturating::new(cast(clamp(i, min, max)).assume())
     }
 
     /// Lossy conversion between saturating integers.
+    #[inline(always)]
     pub fn cast<U: Bounds>(&self) -> Saturating<U> {
         Saturating::saturate(self.get())
     }
@@ -57,18 +61,21 @@ impl<T: Bounds> Saturating<T> {
 impl<T: Bounds> Copy for Saturating<T> {}
 
 impl<T: Bounds> Clone for Saturating<T> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         *self
     }
 }
 
 impl<T: Bounds> Hash for Saturating<T> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_i32(self.get().as_());
     }
 }
 
 impl<T: Bounds> From<Saturating<T>> for i32 {
+    #[inline(always)]
     fn from(s: Saturating<T>) -> Self {
         s.get().into()
     }
@@ -77,30 +84,35 @@ impl<T: Bounds> From<Saturating<T>> for i32 {
 impl<T: Bounds> Eq for Saturating<T> {}
 
 impl<T: Bounds, U: Bounds> PartialEq<Saturating<U>> for Saturating<T> {
+    #[inline(always)]
     fn eq(&self, other: &Saturating<U>) -> bool {
         self.eq(&other.get())
     }
 }
 
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> PartialEq<U> for Saturating<T> {
+    #[inline(always)]
     fn eq(&self, other: &U) -> bool {
         i32::eq(&self.get().as_(), &other.as_())
     }
 }
 
 impl<T: Bounds> Ord for Saturating<T> {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.get().cmp(&other.get())
     }
 }
 
 impl<T: Bounds, U: Bounds> PartialOrd<Saturating<U>> for Saturating<T> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Saturating<U>) -> Option<Ordering> {
         self.partial_cmp(&other.get())
     }
 }
 
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> PartialOrd<U> for Saturating<T> {
+    #[inline(always)]
     fn partial_cmp(&self, other: &U) -> Option<Ordering> {
         i32::partial_cmp(&self.get().as_(), &other.as_())
     }
@@ -109,6 +121,7 @@ impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> PartialOrd<U> for Sat
 impl<T: Bounds> Neg for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Saturating::saturate(i32::saturating_neg(self.get().as_()))
     }
@@ -117,6 +130,7 @@ impl<T: Bounds> Neg for Saturating<T> {
 impl<T: Bounds, U: Bounds> Add<Saturating<U>> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn add(self, rhs: Saturating<U>) -> Self::Output {
         self + rhs.get()
     }
@@ -125,6 +139,7 @@ impl<T: Bounds, U: Bounds> Add<Saturating<U>> for Saturating<T> {
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Add<U> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn add(self, rhs: U) -> Self::Output {
         Saturating::saturate(i32::saturating_add(self.get().as_(), rhs.as_()))
     }
@@ -133,6 +148,7 @@ impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Add<U> for Saturating
 impl<T: Bounds, U: Bounds> Sub<Saturating<U>> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn sub(self, rhs: Saturating<U>) -> Self::Output {
         self - rhs.get()
     }
@@ -141,6 +157,7 @@ impl<T: Bounds, U: Bounds> Sub<Saturating<U>> for Saturating<T> {
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Sub<U> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn sub(self, rhs: U) -> Self::Output {
         Saturating::saturate(i32::saturating_sub(self.get().as_(), rhs.as_()))
     }
@@ -149,6 +166,7 @@ impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Sub<U> for Saturating
 impl<T: Bounds, U: Bounds> Mul<Saturating<U>> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: Saturating<U>) -> Self::Output {
         self * rhs.get()
     }
@@ -157,6 +175,7 @@ impl<T: Bounds, U: Bounds> Mul<Saturating<U>> for Saturating<T> {
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Mul<U> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: U) -> Self::Output {
         Saturating::saturate(i32::saturating_mul(self.get().as_(), rhs.as_()))
     }
@@ -165,6 +184,7 @@ impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Mul<U> for Saturating
 impl<T: Bounds, U: Bounds> Div<Saturating<U>> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: Saturating<U>) -> Self::Output {
         self / rhs.get()
     }
@@ -173,6 +193,7 @@ impl<T: Bounds, U: Bounds> Div<Saturating<U>> for Saturating<T> {
 impl<T: Bounds, U: PrimInt + Into<i32> + AsPrimitive<i32>> Div<U> for Saturating<T> {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: U) -> Self::Output {
         Saturating::saturate(i32::saturating_div(self.get().as_(), rhs.as_()))
     }


### PR DESCRIPTION
### Callgrind

> `valgrind --tool=callgrind --dump-instr=yes --collect-jumps=yes --cache-sim=yes --branch-sim=yes target/release/cli <<EOF
uci
go nodes 100000
quit
EOF`

```
==1862113== 
==1862113== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw Bc Bcm Bi Bim
==1862113== Collected : 1738884120 602493438 308755434 20011145 55199910 16405999 4208 34893 269862 92610547 4941165 3301361 1989578
==1862113== 
==1862113== I   refs:      1,738,884,120
==1862113== I1  misses:       20,011,145
==1862113== LLi misses:            4,208
==1862113== I1  miss rate:          1.15%
==1862113== LLi miss rate:          0.00%
==1862113== 
==1862113== D   refs:        911,248,872  (602,493,438 rd + 308,755,434 wr)
==1862113== D1  misses:       71,605,909  ( 55,199,910 rd +  16,405,999 wr)
==1862113== LLd misses:          304,755  (     34,893 rd +     269,862 wr)
==1862113== D1  miss rate:           7.9% (        9.2%   +         5.3%  )
==1862113== LLd miss rate:           0.0% (        0.0%   +         0.1%  )
==1862113== 
==1862113== LL refs:          91,617,054  ( 75,211,055 rd +  16,405,999 wr)
==1862113== LL misses:           308,963  (     39,101 rd +     269,862 wr)
==1862113== LL miss rate:            0.0% (        0.0%   +         0.1%  )
==1862113== 
==1862113== Branches:         95,911,908  ( 92,610,547 cond +   3,301,361 ind)
==1862113== Mispredicts:       6,930,743  (  4,941,165 cond +   1,989,578 ind)
==1862113== Mispred rate:            7.2% (        5.3%     +        60.3%   )
```

```
==1826895== 
==1826895== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw Bc Bcm Bi Bim
==1826895== Collected : 1689996270 586940332 303190617 18698928 55703782 16699901 4225 35014 269876 92002141 5156172 3301361 1989569
==1826895== 
==1826895== I   refs:      1,689,996,270
==1826895== I1  misses:       18,698,928
==1826895== LLi misses:            4,225
==1826895== I1  miss rate:          1.11%
==1826895== LLi miss rate:          0.00%
==1826895== 
==1826895== D   refs:        890,130,949  (586,940,332 rd + 303,190,617 wr)
==1826895== D1  misses:       72,403,683  ( 55,703,782 rd +  16,699,901 wr)
==1826895== LLd misses:          304,890  (     35,014 rd +     269,876 wr)
==1826895== D1  miss rate:           8.1% (        9.5%   +         5.5%  )
==1826895== LLd miss rate:           0.0% (        0.0%   +         0.1%  )
==1826895== 
==1826895== LL refs:          91,102,611  ( 74,402,710 rd +  16,699,901 wr)
==1826895== LL misses:           309,115  (     39,239 rd +     269,876 wr)
==1826895== LL miss rate:            0.0% (        0.0%   +         0.1%  )
==1826895== 
==1826895== Branches:         95,303,502  ( 92,002,141 cond +   3,301,361 ind)
==1826895== Mispredicts:       7,145,741  (  5,156,172 cond +   1,989,569 ind)
==1826895== Mispred rate:            7.5% (        5.6%     +        60.3%   )
```

### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```

```

