### PR TITLE
Improve quality of code generated

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 [build]
 rustflags = ["-Ctarget-cpu=native"]
+
+[unstable]
+profile-rustflags = true
+
+[profile.release]
+rustflags = ["-Zlocation-detail=none"]

--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -96,6 +96,7 @@ impl IntoIterator for Bitboard {
 
 #[doc(hidden)]
 impl From<cc::BitBoard> for Bitboard {
+    #[inline(always)]
     fn from(bb: cc::BitBoard) -> Self {
         Bitboard(bb)
     }
@@ -103,6 +104,7 @@ impl From<cc::BitBoard> for Bitboard {
 
 #[doc(hidden)]
 impl From<Bitboard> for cc::BitBoard {
+    #[inline(always)]
     fn from(bb: Bitboard) -> Self {
         bb.0
     }

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -26,6 +26,7 @@ impl Not for Color {
 
 #[doc(hidden)]
 impl From<cc::Color> for Color {
+    #[inline(always)]
     fn from(c: cc::Color) -> Self {
         match c {
             cc::Color::White => Color::White,
@@ -36,6 +37,7 @@ impl From<cc::Color> for Color {
 
 #[doc(hidden)]
 impl From<Color> for cc::Color {
+    #[inline(always)]
     fn from(c: Color) -> Self {
         match c {
             Color::White => cc::Color::White,

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -72,6 +72,7 @@ impl Sub for File {
 
 #[doc(hidden)]
 impl From<cc::File> for File {
+    #[inline(always)]
     fn from(f: cc::File) -> Self {
         File::from_index(f as _)
     }
@@ -79,6 +80,7 @@ impl From<cc::File> for File {
 
 #[doc(hidden)]
 impl From<File> for cc::File {
+    #[inline(always)]
     fn from(f: File) -> Self {
         cc::File::index_const(f as _)
     }

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -10,11 +10,13 @@ use vampirc_uci::UciMove;
 pub struct Move(NonZeroU16);
 
 impl Move {
+    #[inline(always)]
     fn bits<R: RangeBounds<u32>>(&self, r: R) -> Bits<u16, 16> {
         Bits::new(self.0.get()).slice(r)
     }
 
     /// Constructs a castling move.
+    #[inline(always)]
     pub fn castling(whence: Square, whither: Square) -> Self {
         let mut bits = Bits::<_, 16>::default();
         bits.push(whence.encode());
@@ -24,6 +26,7 @@ impl Move {
     }
 
     /// Constructs an en passant move.
+    #[inline(always)]
     pub fn en_passant(whence: Square, whither: Square) -> Self {
         let mut bits = Bits::<_, 16>::default();
         bits.push(whence.encode());
@@ -33,6 +36,7 @@ impl Move {
     }
 
     /// Constructs a regular move.
+    #[inline(always)]
     pub fn regular(
         whence: Square,
         whither: Square,
@@ -57,16 +61,19 @@ impl Move {
     }
 
     /// The source [`Square`].
+    #[inline(always)]
     pub fn whence(&self) -> Square {
         Square::decode(self.bits(10..).pop()).assume()
     }
 
     /// The destination [`Square`].
+    #[inline(always)]
     pub fn whither(&self) -> Square {
         Square::decode(self.bits(4..).pop()).assume()
     }
 
     /// The promotion specifier.
+    #[inline(always)]
     pub fn promotion(&self) -> Option<Role> {
         if self.is_promotion() {
             Some(Role::from_index(self.bits(..2).get() as u8 + 1))
@@ -76,26 +83,31 @@ impl Move {
     }
 
     /// Whether this is a promotion move.
+    #[inline(always)]
     pub fn is_promotion(&self) -> bool {
         self.bits(3..=3).get() != 0
     }
 
     /// Whether this is a castling move.
+    #[inline(always)]
     pub fn is_castling(&self) -> bool {
         self.bits(..4).get() == 0b0001
     }
 
     /// Whether this is an en passant capture move.
+    #[inline(always)]
     pub fn is_en_passant(&self) -> bool {
         self.bits(..4).get() == 0b0011
     }
 
     /// Whether this is a capture move.
+    #[inline(always)]
     pub fn is_capture(&self) -> bool {
         self.bits(2..=2).get() != 0 || (self.bits(1..=1).get() != 0 && !self.is_promotion())
     }
 
     /// Whether this move is neither a capture nor a promotion.
+    #[inline(always)]
     pub fn is_quiet(&self) -> bool {
         !(self.is_capture() || self.is_promotion())
     }

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -31,16 +31,18 @@ pub struct Position {
 }
 
 impl Hash for Position {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.zobrist().get())
+        self.zobrist().hash(state)
     }
 }
 
 impl Eq for Position {}
 
 impl PartialEq for Position {
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
-        self.board == other.board
+        self.board.eq(&other.board)
     }
 }
 
@@ -90,6 +92,7 @@ impl Arbitrary for Position {
 
 impl Position {
     /// The side to move.
+    #[inline(always)]
     pub fn turn(&self) -> Color {
         self.board.side_to_move().into()
     }
@@ -97,6 +100,7 @@ impl Position {
     /// The number of halfmoves since the last capture or pawn advance.
     ///
     /// It resets to 0 whenever a piece is captured or a pawn is moved.
+    #[inline(always)]
     pub fn halfmoves(&self) -> u8 {
         self.board.halfmove_clock()
     }
@@ -104,11 +108,13 @@ impl Position {
     /// The current move number since the start of the game.
     ///
     /// It starts at 1, and is incremented after every move by black.
+    #[inline(always)]
     pub fn fullmoves(&self) -> NonZeroU32 {
         NonZeroU32::new(self.board.fullmove_number() as _).assume()
     }
 
     /// The en passant square.
+    #[inline(always)]
     pub fn en_passant(&self) -> Option<Square> {
         self.board.en_passant().map(|f| match self.turn() {
             Color::White => Square::new(f.into(), Rank::Sixth),
@@ -119,56 +125,67 @@ impl Position {
     /// This position's [zobrist hash].
     ///
     /// [zobrist hash]: https://www.chessprogramming.org/Zobrist_Hashing
+    #[inline(always)]
     pub fn zobrist(&self) -> Zobrist {
         Bits::new(self.board.hash())
     }
 
     /// An iterator over all pieces on the board.
+    #[inline(always)]
     pub fn iter(&self) -> impl ExactSizeIterator<Item = (Piece, Square)> + '_ {
         self.occupied().into_iter().map(|s| (self[s].assume(), s))
     }
 
     /// [`Square`]s occupied.
+    #[inline(always)]
     pub fn occupied(&self) -> Bitboard {
         self.board.occupied().into()
     }
 
     /// [`Square`]s occupied by a [`Color`].
+    #[inline(always)]
     pub fn by_color(&self, c: Color) -> Bitboard {
         self.board.colors(c.into()).into()
     }
 
     /// [`Square`]s occupied by a [`Role`].
+    #[inline(always)]
     pub fn by_role(&self, r: Role) -> Bitboard {
         self.board.pieces(r.into()).into()
     }
 
     /// [`Square`]s occupied by a [`Piece`].
+    #[inline(always)]
     pub fn by_piece(&self, Piece(c, r): Piece) -> Bitboard {
         self.board.colored_pieces(c.into(), r.into()).into()
     }
 
     /// [`Square`] occupied by a the king of the given color.
+    #[inline(always)]
     pub fn king(&self, side: Color) -> Square {
         self.board.king(side.into()).into()
     }
 
     /// The [`Role`] of the piece on the given [`Square`], if any.
+    #[inline(always)]
     pub fn role_on(&self, s: Square) -> Option<Role> {
         self.board.piece_on(s.into()).map(Role::from)
     }
 
     /// The [`Color`] of the piece on the given [`Square`], if any.
+    #[inline(always)]
     pub fn color_on(&self, s: Square) -> Option<Color> {
         self.board.color_on(s.into()).map(Color::from)
     }
 
     /// The [`Piece`] on the given [`Square`], if any.
+    #[inline(always)]
     pub fn piece_on(&self, s: Square) -> Option<Piece> {
         Option::zip(self.color_on(s), self.role_on(s)).map(|(c, r)| Piece(c, r))
     }
 
     /// Into where a [`Piece`] on this [`Square`] can attack.
+    #[inline(always)]
     pub fn attacks(&self, s: Square, Piece(c, r): Piece) -> Bitboard {
         let blk = self.occupied().into();
 
@@ -183,11 +200,13 @@ impl Position {
     }
 
     /// From where a [`Piece`] can attack into this [`Square`].
+    #[inline(always)]
     pub fn attackers(&self, s: Square, p: Piece) -> Bitboard {
         self.attacks(s, p.mirror())
     }
 
     /// How many other times this position has repeated.
+    #[inline(always)]
     pub fn repetitions(&self) -> usize {
         let zobrist = self.zobrist().pop();
         let history = &self.history[self.turn() as usize];
@@ -197,6 +216,7 @@ impl Position {
     /// Whether this position is a [check].
     ///
     /// [check]: https://www.chessprogramming.org/Check
+    #[inline(always)]
     pub fn is_check(&self) -> bool {
         !self.board.checkers().is_empty()
     }
@@ -204,6 +224,7 @@ impl Position {
     /// Whether this position is a [checkmate].
     ///
     /// [checkmate]: https://www.chessprogramming.org/Checkmate
+    #[inline(always)]
     pub fn is_checkmate(&self) -> bool {
         self.is_check() & !self.board.generate_moves(|_| true)
     }
@@ -211,6 +232,7 @@ impl Position {
     /// Whether this position is a [stalemate].
     ///
     /// [stalemate]: https://www.chessprogramming.org/Stalemate
+    #[inline(always)]
     pub fn is_stalemate(&self) -> bool {
         !self.is_check() & !self.board.generate_moves(|_| true)
     }
@@ -218,6 +240,7 @@ impl Position {
     /// Whether the game is a draw by [Threefold repetition].
     ///
     /// [Threefold repetition]: https://en.wikipedia.org/wiki/Threefold_repetition
+    #[inline(always)]
     pub fn is_draw_by_threefold_repetition(&self) -> bool {
         self.repetitions() > 1
     }
@@ -225,6 +248,7 @@ impl Position {
     /// Whether the game is a draw by the [50-move rule].
     ///
     /// [50-move rule]: https://en.wikipedia.org/wiki/Fifty-move_rule
+    #[inline(always)]
     pub fn is_draw_by_50_move_rule(&self) -> bool {
         self.halfmoves() >= 100
     }
@@ -232,6 +256,7 @@ impl Position {
     /// Whether this position has [insufficient material].
     ///
     /// [insufficient material]: https://www.chessprogramming.org/Material#InsufficientMaterial
+    #[inline(always)]
     pub fn is_material_insufficient(&self) -> bool {
         match self.occupied().len() {
             2 => true,
@@ -246,6 +271,7 @@ impl Position {
     }
 
     /// The [`Outcome`] of the game in case this position is final.
+    #[inline(always)]
     pub fn outcome(&self) -> Option<Outcome> {
         if self.is_checkmate() {
             Some(Outcome::Checkmate(!self.turn()))
@@ -263,6 +289,7 @@ impl Position {
     }
 
     /// An iterator over the legal [`Move`]s that can be played from a subset of squares in this position.
+    #[inline(always)]
     pub fn moves(&self, whence: Bitboard) -> impl Iterator<Item = Move> + '_ {
         let mut moves = Buffer::<_, 18>::new();
         self.board.generate_moves_for(whence.into(), |ms| {
@@ -298,6 +325,7 @@ impl Position {
     }
 
     /// Play a [`Move`].
+    #[inline(always)]
     pub fn play(&mut self, m: Move) {
         let from = m.whence();
         let to = if !m.is_castling() {
@@ -330,6 +358,7 @@ impl Position {
     /// Play a [null-move].
     ///
     /// [null-move]: https://www.chessprogramming.org/Null_Move
+    #[inline(always)]
     pub fn pass(&mut self) {
         debug_assert!(!self.is_check(), "null move is illegal in `{self}`");
         self.board = self.board.null_move().assume();
@@ -337,6 +366,7 @@ impl Position {
     }
 
     /// Exchange a piece on [`Square`] by the attacker of least value.
+    #[inline(always)]
     pub fn exchange(&mut self, whither: Square) -> Result<Move, ImpossibleExchange> {
         let turn = self.turn();
         let capture = match self[whither] {
@@ -354,7 +384,8 @@ impl Position {
                 };
 
                 if let Some(m) = ms.into_iter().max_by_key(|m| m.promotion) {
-                    if self.board.try_play(m).is_ok() {
+                    if self.board.is_legal(m) {
+                        self.board.play_unchecked(m);
                         self.history = Default::default();
                         let promotion = m.promotion.map(Role::from);
                         return Ok(Move::regular(whence, whither, promotion, capture));
@@ -371,6 +402,7 @@ impl Position {
 impl Index<Square> for Position {
     type Output = Option<Piece>;
 
+    #[inline(always)]
     fn index(&self, s: Square) -> &Self::Output {
         use {Color::*, Role::*};
         match self.piece_on(s) {

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -72,6 +72,7 @@ impl Sub for Rank {
 
 #[doc(hidden)]
 impl From<cc::Rank> for Rank {
+    #[inline(always)]
     fn from(r: cc::Rank) -> Self {
         Rank::from_index(r as _)
     }
@@ -79,6 +80,7 @@ impl From<cc::Rank> for Rank {
 
 #[doc(hidden)]
 impl From<Rank> for cc::Rank {
+    #[inline(always)]
     fn from(r: Rank) -> Self {
         cc::Rank::index_const(r as _)
     }

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -81,6 +81,7 @@ impl From<UciPiece> for Role {
 
 #[doc(hidden)]
 impl From<Role> for cc::Piece {
+    #[inline(always)]
     fn from(r: Role) -> Self {
         cc::Piece::index_const(r as _)
     }
@@ -88,6 +89,7 @@ impl From<Role> for cc::Piece {
 
 #[doc(hidden)]
 impl From<cc::Piece> for Role {
+    #[inline(always)]
     fn from(r: cc::Piece) -> Self {
         Role::from_index(r as _)
     }

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -124,6 +124,7 @@ impl From<UciSquare> for Square {
 
 #[doc(hidden)]
 impl From<cc::Square> for Square {
+    #[inline(always)]
     fn from(s: cc::Square) -> Self {
         Square::from_index(s as _)
     }
@@ -131,6 +132,7 @@ impl From<cc::Square> for Square {
 
 #[doc(hidden)]
 impl From<Square> for cc::Square {
+    #[inline(always)]
     fn from(s: Square) -> Self {
         cc::Square::index_const(s as _)
     }

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -105,7 +105,8 @@ impl<T: Clone + Accumulator> Evaluator<T> {
     /// Exchange a piece on [`Square`] by the attacker of least value.
     ///
     /// This may lead to invalid positions.
-    pub fn exchange(&mut self, whither: Square) -> Result<Move, ImpossibleExchange> {
+    #[inline(always)]
+    fn exchange(&mut self, whither: Square) -> Result<Move, ImpossibleExchange> {
         let capture = self.role_on(whither);
         let m = self.pos.exchange(whither)?;
         self.acc.mirror();
@@ -113,6 +114,7 @@ impl<T: Clone + Accumulator> Evaluator<T> {
         Ok(m)
     }
 
+    #[inline(always)]
     fn update(&mut self, m: Move, capture: Option<Role>) {
         let turn = self.turn();
 

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -4,7 +4,7 @@ use std::convert::Infallible;
 pub struct DepthBounds;
 
 impl Bounds for DepthBounds {
-    type Integer = u8;
+    type Integer = i8;
 
     const LOWER: Self::Integer = 0;
 
@@ -23,11 +23,11 @@ impl Binary for Depth {
     type Error = Infallible;
 
     fn encode(&self) -> Self::Bits {
-        Bits::new(self.get())
+        Bits::new(self.get() as _)
     }
 
     fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
-        Ok(Depth::new(bits.get()))
+        Ok(Depth::new(bits.get() as _))
     }
 }
 

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -56,7 +56,7 @@ impl Binary for Score {
 
     fn decode(bits: Self::Bits) -> Result<Self, Self::Error> {
         if bits != !Bits::default() {
-            Ok(Self::LOWER + bits.get())
+            Ok(Self::LOWER + bits.get() as i16)
         } else {
             Err(DecodeScoreError)
         }

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -572,7 +572,7 @@ mod tests {
 
         let reply = uci.process(UciMessage::Go {
             time_control: None,
-            search_control: Some(UciSearchControl::depth(d.get())),
+            search_control: Some(UciSearchControl::depth(d.get() as _)),
         });
 
         assert!(reply.is_some_and(|v| v.iter().any(|m| matches!(m, UciMessage::BestMove { .. }))));

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -9,6 +9,7 @@ use proptest::prelude::*;
 #[cfg(test)]
 use std::ops::RangeInclusive;
 
+#[inline(always)]
 fn ones<T: PrimInt + Unsigned>(n: u32) -> T {
     match n {
         0 => T::zero(),
@@ -33,17 +34,20 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics if `b` is too wide.
+    #[inline(always)]
     pub fn new(b: T) -> Self {
         assert!(b <= ones(W));
         Bits(b)
     }
 
     /// Get raw collection of bits.
+    #[inline(always)]
     pub fn get(&self) -> T {
         self.0
     }
 
     /// Returns a slice of bits.
+    #[inline(always)]
     pub fn slice<R: RangeBounds<u32>>(&self, r: R) -> Self {
         let a = match r.start_bound() {
             Bound::Included(&i) => i,
@@ -65,6 +69,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics on overflow.
+    #[inline(always)]
     pub fn push<U: 'static + Binary + PrimInt + Unsigned + AsPrimitive<T>, const N: u32>(
         &mut self,
         bits: Bits<U, N>,
@@ -77,6 +82,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
     /// # Panics
     ///
     /// Panics on underflow.
+    #[inline(always)]
     pub fn pop<U: 'static + Binary + PrimInt + Unsigned, const N: u32>(&mut self) -> Bits<U, N>
     where
         T: AsPrimitive<U>,
@@ -88,6 +94,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Bits<T, W> {
 }
 
 impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Default for Bits<T, W> {
+    #[inline(always)]
     fn default() -> Self {
         Bits::new(T::zero())
     }
@@ -96,6 +103,7 @@ impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Default for Bits<T,
 impl<T: 'static + Binary + PrimInt + Unsigned, const W: u32> Not for Bits<T, W> {
     type Output = Self;
 
+    #[inline(always)]
     fn not(self) -> Self::Output {
         Bits::new(!self.get() & ones(W))
     }

--- a/lib/util/bounds.rs
+++ b/lib/util/bounds.rs
@@ -1,9 +1,9 @@
-use num_traits::{AsPrimitive, PrimInt};
+use num_traits::{PrimInt, Signed};
 
 /// Trait for integer bounds.
 pub trait Bounds {
     /// The equivalent primitive integer
-    type Integer: PrimInt + Into<i32> + AsPrimitive<i32>;
+    type Integer: PrimInt + Signed;
 
     /// The lower bound.
     const LOWER: Self::Integer;

--- a/lib/util/saturating.rs
+++ b/lib/util/saturating.rs
@@ -110,17 +110,20 @@ impl<T: Bounds> Saturating<T> {
     /// # Panics
     ///
     /// Panics if `i` is outside of the bounds.
+    #[inline(always)]
     pub fn new(i: T::Integer) -> Self {
         assert!((T::LOWER..=T::UPPER).contains(&i));
         Saturating(i)
     }
 
     /// Returns the raw integer.
+    #[inline(always)]
     pub const fn get(&self) -> T::Integer {
         self.0
     }
 
     /// Constructs `Self` from a raw integer through saturation.
+    #[inline(always)]
     pub fn saturate<I: PrimInt>(i: I) -> Self {
         let min = cast(T::LOWER).unwrap_or_else(I::min_value);
         let max = cast(T::UPPER).unwrap_or_else(I::max_value);
@@ -128,6 +131,7 @@ impl<T: Bounds> Saturating<T> {
     }
 
     /// Lossy conversion between saturating integers.
+    #[inline(always)]
     pub fn cast<U: Bounds>(&self) -> Saturating<U> {
         Saturating::saturate(self.get())
     }
@@ -136,6 +140,7 @@ impl<T: Bounds> Saturating<T> {
 impl<T: Bounds> Copy for Saturating<T> {}
 
 impl<T: Bounds> Clone for Saturating<T> {
+    #[inline(always)]
     fn clone(&self) -> Self {
         *self
     }
@@ -147,6 +152,7 @@ impl<T: Bounds, U: Bounds> PartialEq<Saturating<U>> for Saturating<T>
 where
     Self: PartialEq<U::Integer>,
 {
+    #[inline(always)]
     fn eq(&self, other: &Saturating<U>) -> bool {
         self.eq(&other.get())
     }
@@ -156,6 +162,7 @@ impl<T: Bounds> Ord for Saturating<T>
 where
     Self: PartialEq<Self> + PartialOrd,
 {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.get().cmp(&other.get())
     }
@@ -165,12 +172,14 @@ impl<T: Bounds, U: Bounds> PartialOrd<Saturating<U>> for Saturating<T>
 where
     Self: PartialOrd<U::Integer>,
 {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Saturating<U>) -> Option<Ordering> {
         self.partial_cmp(&other.get())
     }
 }
 
 impl<T: Bounds<Integer = I>, I: Hash> Hash for Saturating<T> {
+    #[inline(always)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.get().hash(state)
     }
@@ -185,6 +194,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn add(self, rhs: Saturating<U>) -> Self::Output {
         self + rhs.get()
     }
@@ -199,6 +209,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn sub(self, rhs: Saturating<U>) -> Self::Output {
         self - rhs.get()
     }
@@ -213,6 +224,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: Saturating<U>) -> Self::Output {
         self * rhs.get()
     }
@@ -227,6 +239,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: Saturating<U>) -> Self::Output {
         self / rhs.get()
     }
@@ -239,6 +252,7 @@ where
     K: 'static + PrimInt,
     (I, J): Larger<Integer = K>,
 {
+    #[inline(always)]
     fn eq(&self, other: &J) -> bool {
         K::eq(&self.get().as_(), &other.as_())
     }
@@ -251,6 +265,7 @@ where
     K: 'static + PrimInt,
     (I, J): Larger<Integer = K>,
 {
+    #[inline(always)]
     fn partial_cmp(&self, other: &J) -> Option<Ordering> {
         K::partial_cmp(&self.get().as_(), &other.as_())
     }
@@ -263,6 +278,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn neg(self) -> Self::Output {
         Saturating::saturate(J::neg(self.get().as_()))
     }
@@ -277,6 +293,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn add(self, rhs: J) -> Self::Output {
         Saturating::saturate(K::add(self.get().as_(), rhs.as_()))
     }
@@ -291,6 +308,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn sub(self, rhs: J) -> Self::Output {
         Saturating::saturate(K::sub(self.get().as_(), rhs.as_()))
     }
@@ -305,6 +323,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn mul(self, rhs: J) -> Self::Output {
         Saturating::saturate(K::mul(self.get().as_(), rhs.as_()))
     }
@@ -319,6 +338,7 @@ where
 {
     type Output = Self;
 
+    #[inline(always)]
     fn div(self, rhs: J) -> Self::Output {
         Saturating::saturate(K::div(self.get().as_(), rhs.as_()))
     }


### PR DESCRIPTION
### Callgrind

> `valgrind --tool=callgrind --dump-instr=yes --collect-jumps=yes --cache-sim=yes --branch-sim=yes <cli> <<EOF
go nodes 100000
EOF`

```
==721543== Callgrind, a call-graph generating cache profiler
==721543== Copyright (C) 2002-2017, and GNU GPL'd, by Josef Weidendorfer et al.
==721543== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==721543== Command: engines/base
==721543== 
--721543-- warning: L3 cache found, using its data for the LL simulation.
==721543== For interactive control, run 'callgrind_control -h'.
info score cp 34 pv d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c1g5 c7c5 c4d5 c5d4 d1d4
bestmove d2d4
==721543== 
==721543== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw Bc Bcm Bi Bim
==721543== Collected : 1725624658 597042803 301171008 13332658 51602269 12251903 4121 32416 267142 91463315 4906106 3406255 2064230
==721543== 
==721543== I   refs:      1,725,624,658
==721543== I1  misses:       13,332,658
==721543== LLi misses:            4,121
==721543== I1  miss rate:          0.77%
==721543== LLi miss rate:          0.00%
==721543== 
==721543== D   refs:        898,213,811  (597,042,803 rd + 301,171,008 wr)
==721543== D1  misses:       63,854,172  ( 51,602,269 rd +  12,251,903 wr)
==721543== LLd misses:          299,558  (     32,416 rd +     267,142 wr)
==721543== D1  miss rate:           7.1% (        8.6%   +         4.1%  )
==721543== LLd miss rate:           0.0% (        0.0%   +         0.1%  )
==721543== 
==721543== LL refs:          77,186,830  ( 64,934,927 rd +  12,251,903 wr)
==721543== LL misses:           303,679  (     36,537 rd +     267,142 wr)
==721543== LL miss rate:            0.0% (        0.0%   +         0.1%  )
==721543== 
==721543== Branches:         94,869,570  ( 91,463,315 cond +   3,406,255 ind)
==721543== Mispredicts:       6,970,336  (  4,906,106 cond +   2,064,230 ind)
==721543== Mispred rate:            7.3% (        5.4%     +        60.6%   )
```

```
==722425== Callgrind, a call-graph generating cache profiler
==722425== Copyright (C) 2002-2017, and GNU GPL'd, by Josef Weidendorfer et al.
==722425== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==722425== Command: engines/dev
==722425== 
--722425-- warning: L3 cache found, using its data for the LL simulation.
==722425== For interactive control, run 'callgrind_control -h'.
info score cp 34 pv d2d4 g8f6 c2c4 e7e6 b1c3 d7d5 c1g5 c7c5 c4d5 c5d4 d1d4
bestmove d2d4
==722425== 
==722425== Events    : Ir Dr Dw I1mr D1mr D1mw ILmr DLmr DLmw Bc Bcm Bi Bim
==722425== Collected : 1663235388 578141615 293224960 23009976 52763542 13670086 4463 32763 267349 89660959 4901258 3717656 2217967
==722425== 
==722425== I   refs:      1,663,235,388
==722425== I1  misses:       23,009,976
==722425== LLi misses:            4,463
==722425== I1  miss rate:          1.38%
==722425== LLi miss rate:          0.00%
==722425== 
==722425== D   refs:        871,366,575  (578,141,615 rd + 293,224,960 wr)
==722425== D1  misses:       66,433,628  ( 52,763,542 rd +  13,670,086 wr)
==722425== LLd misses:          300,112  (     32,763 rd +     267,349 wr)
==722425== D1  miss rate:           7.6% (        9.1%   +         4.7%  )
==722425== LLd miss rate:           0.0% (        0.0%   +         0.1%  )
==722425== 
==722425== LL refs:          89,443,604  ( 75,773,518 rd +  13,670,086 wr)
==722425== LL misses:           304,575  (     37,226 rd +     267,349 wr)
==722425== LL miss rate:            0.0% (        0.0%   +         0.1%  )
==722425== 
==722425== Branches:         93,378,615  ( 89,660,959 cond +   3,717,656 ind)
==722425== Mispredicts:       7,119,225  (  4,901,258 cond +   2,217,967 ind)
==722425== Mispred rate:            7.6% (        5.5%     +        59.7%   )
```

### SPRT

> `cutechess-cli -sprt elo0=0 elo1=10 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 647 - 586 - 847  [0.515] 2080
...      dev playing White: 353 - 273 - 413  [0.538] 1039
...      dev playing Black: 294 - 313 - 434  [0.491] 1041
...      White vs Black: 666 - 567 - 847  [0.524] 2080
Elo difference: 10.2 +/- 11.5, LOS: 95.9 %, DrawRatio: 40.7 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 5 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Nalwald-18 -engine conf=Counter-5.0 -engine conf=StockNemo-5.7 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -76       6    9000    2151    4079    2770   3536.0   39.3%   30.8% 
   1 Nalwald-18                    101      10    3000    1427     577     996   1925.0   64.2%   33.2% 
   2 Counter-5.0                    77      11    3000    1422     767     811   1827.5   60.9%   27.0% 
   3 StockNemo-5.7                  49      10    3000    1230     807     963   1711.5   57.0%   32.1%
```
