### PR TITLE
Disable feature pext of crate cozy-chess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,6 @@ derive_more = { version = "1.0.0-beta.6", default-features = false, features = [
 num-traits = { version = "0.2.17", default-features = false, features = ["std"] }
 rayon = { version = "1.8.0", default-features = false }
 
-[target.'cfg(all(target_arch = "x86_64", target_feature = "bmi2"))'.dependencies.cozy-chess]
-version = "0.3.3"
-default-features = false
-features = ["pext"]
-
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = ["rayon"] }
 num_cpus = { version = "1.16.0", default-features = false }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 4 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=Nalwald-18 -engine conf=Counter-5.0 -engine conf=StockNemo-5.7 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -73       6    9000    2149    4016    2835   3566.5   39.6%   31.5% 
   1 Nalwald-18                    103      10    3000    1433     569     998   1932.0   64.4%   33.3% 
   2 Counter-5.0                    83      11    3000    1433     732     835   1850.5   61.7%   27.8% 
   3 StockNemo-5.7                  35      10    3000    1150     848    1002   1651.0   55.0%   33.4%
```