### PR TITLE
Constify trait Assume and struct Bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ dependencies = [
  "criterion",
  "ctor",
  "derive_more",
- "num-traits",
  "proptest",
  "rayon",
  "ruzstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ derive_more = { version = "1.0.0-beta.6", default-features = false, features = [
     "mul_assign",
     "not",
 ] }
-num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 rayon = { version = "1.10.0", default-features = false }
 ruzstd = { version = "0.7.0", default-features = false, features = ["std"] }
 

--- a/benches/search.rs
+++ b/benches/search.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode, Throughput};
-use lib::search::{Depth, Engine, Options, ThreadCount};
-use lib::{chess::Position, search::Limits};
+use lib::search::{Depth, Engine, Limits, Options, ThreadCount};
+use lib::{chess::Position, util::Integer};
 use std::thread::available_parallelism;
 use std::time::{Duration, Instant};
 

--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -113,17 +113,17 @@ mod tests {
     use std::fmt::Debug;
     use test_strategy::proptest;
 
-    #[proptest]
+    #[test]
     fn empty_constructs_board_with_no_squares() {
         assert_eq!(Bitboard::empty().into_iter().count(), 0);
     }
 
-    #[proptest]
+    #[test]
     fn full_constructs_board_with_all_squares() {
         assert_eq!(Bitboard::full().into_iter().count(), 64);
     }
 
-    #[proptest]
+    #[test]
     fn light_and_dark_bitboards_are_complementary() {
         assert_eq!(Bitboard::light() | Bitboard::dark(), Bitboard::full());
         assert_eq!(Bitboard::light() & Bitboard::dark(), Bitboard::empty());

--- a/lib/chess/color.rs
+++ b/lib/chess/color.rs
@@ -67,7 +67,7 @@ mod tests {
     use std::mem::size_of;
     use test_strategy::proptest;
 
-    #[proptest]
+    #[test]
     fn color_guarantees_zero_value_optimization() {
         assert_eq!(size_of::<Option<Color>>(), size_of::<Color>());
     }

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -24,19 +24,19 @@ impl Piece {
     /// Constructs [`Piece`] from a pair of [`Color`] and [`Role`].
     #[inline(always)]
     pub const fn new(r: Role, c: Color) -> Self {
-        Self::from_repr(r.repr() * 2 + c.repr())
+        <Self as Integer>::new(c.get() | r.get() << 1)
     }
 
     /// This piece's [`Role`].
     #[inline(always)]
     pub const fn role(&self) -> Role {
-        Role::from_repr(self.repr() / 2)
+        Role::new(self.get() >> 1)
     }
 
     /// This piece's [`Color`].
     #[inline(always)]
     pub const fn color(&self) -> Color {
-        Color::from_repr(self.repr() % 2)
+        Color::new(self.get() & 0b1)
     }
 }
 
@@ -50,7 +50,7 @@ impl const Perspective for Piece {
     /// Mirrors this piece's [`Color`].
     #[inline(always)]
     fn flip(&self) -> Self {
-        Self::from_repr(self.repr() ^ Piece::BlackPawn.repr())
+        <Self as Integer>::new(self.get() ^ Piece::BlackPawn.get())
     }
 }
 
@@ -60,7 +60,7 @@ mod tests {
     use std::mem::size_of;
     use test_strategy::proptest;
 
-    #[proptest]
+    #[test]
     fn piece_guarantees_zero_value_optimization() {
         assert_eq!(size_of::<Option<Piece>>(), size_of::<Piece>());
     }

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -78,7 +78,7 @@ impl Arbitrary for Position {
                             if board.halfmove_clock() > 0 {
                                 let entries = history[turn as usize].len();
                                 history[turn as usize].copy_within(..entries - 1, 1);
-                                history[turn as usize][0] = NonZeroU32::new(zobrist.get() as _);
+                                history[turn as usize][0] = NonZeroU32::new(zobrist.cast());
                             } else {
                                 history = Default::default();
                             }
@@ -113,7 +113,7 @@ impl Position {
     /// It starts at 1, and is incremented after every move by black.
     #[inline(always)]
     pub fn fullmoves(&self) -> NonZeroU32 {
-        NonZeroU32::new(self.board.fullmove_number() as _).assume()
+        self.board.fullmove_number().convert().assume()
     }
 
     /// The en passant square.
@@ -212,7 +212,7 @@ impl Position {
     /// How many other times this position has repeated.
     #[inline(always)]
     pub fn repetitions(&self) -> usize {
-        match NonZeroU32::new(self.zobrist().get() as _) {
+        match NonZeroU32::new(self.zobrist().cast()) {
             None => 0,
             hash => {
                 let history = self.history[self.turn() as usize];
@@ -365,7 +365,7 @@ impl Position {
         if self.halfmoves() > 0 {
             let entries = self.history[turn as usize].len();
             self.history[turn as usize].copy_within(..entries - 1, 1);
-            self.history[turn as usize][0] = NonZeroU32::new(zobrist.get() as _);
+            self.history[turn as usize][0] = NonZeroU32::new(zobrist.cast());
         } else {
             self.history = Default::default();
         }
@@ -693,7 +693,7 @@ mod tests {
         #[filter(#pos.outcome().is_none())] mut pos: Position,
         z: NonZeroU32,
     ) {
-        let zobrist = NonZeroU32::new(pos.zobrist().get() as _);
+        let zobrist = NonZeroU32::new(pos.zobrist().cast());
         let history = [zobrist, Some(z), zobrist, Some(z)];
         pos.history[pos.turn() as usize][..4].clone_from_slice(&history);
         assert!(pos.is_draw_by_threefold_repetition());

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -7,7 +7,7 @@ use std::ops::Sub;
 /// A row on the chess board.
 #[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[repr(u8)]
+#[repr(i8)]
 pub enum Rank {
     #[display("1")]
     First,
@@ -28,7 +28,7 @@ pub enum Rank {
 }
 
 unsafe impl const Integer for Rank {
-    type Repr = u8;
+    type Repr = i8;
     const MIN: Self::Repr = Rank::First as _;
     const MAX: Self::Repr = Rank::Eighth as _;
 }
@@ -36,7 +36,7 @@ unsafe impl const Integer for Rank {
 impl const Mirror for Rank {
     #[inline(always)]
     fn mirror(&self) -> Self {
-        Rank::from_repr(self.repr() ^ Self::Eighth.repr())
+        Self::new(self.get() ^ Self::Eighth.get())
     }
 }
 
@@ -53,7 +53,7 @@ impl Sub for Rank {
 
     #[inline(always)]
     fn sub(self, rhs: Self) -> Self::Output {
-        self as i8 - rhs as i8
+        self.get() - rhs.get()
     }
 }
 
@@ -61,7 +61,7 @@ impl Sub for Rank {
 impl From<cc::Rank> for Rank {
     #[inline(always)]
     fn from(r: cc::Rank) -> Self {
-        Rank::from_repr(r as _)
+        Self::new(r as _)
     }
 }
 
@@ -79,19 +79,19 @@ mod tests {
     use std::mem::size_of;
     use test_strategy::proptest;
 
-    #[proptest]
+    #[test]
     fn rank_guarantees_zero_value_optimization() {
         assert_eq!(size_of::<Option<Rank>>(), size_of::<Rank>());
     }
 
     #[proptest]
     fn mirroring_rank_returns_complement(r: Rank) {
-        assert_eq!(r.mirror().repr(), Rank::MAX - r.repr());
+        assert_eq!(r.mirror().get(), Rank::MAX - r.get());
     }
 
     #[proptest]
     fn subtracting_ranks_returns_distance(a: Rank, b: Rank) {
-        assert_eq!(a - b, a as i8 - b as i8);
+        assert_eq!(a - b, a.get() - b.get());
     }
 
     #[proptest]

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -39,7 +39,7 @@ impl From<Role> for cc::Piece {
 impl From<cc::Piece> for Role {
     #[inline(always)]
     fn from(r: cc::Piece) -> Self {
-        Role::from_repr(r as _)
+        Self::new(r as _)
     }
 }
 
@@ -49,7 +49,7 @@ mod tests {
     use std::mem::size_of;
     use test_strategy::proptest;
 
-    #[proptest]
+    #[test]
     fn role_guarantees_zero_value_optimization() {
         assert_eq!(size_of::<Option<Role>>(), size_of::<Role>());
     }

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Color, ImpossibleExchange, Move, Piece, Position, Role, Square};
 use crate::nnue::{Accumulator, Feature, Material, Positional, Value};
-use crate::util::Assume;
+use crate::util::{Assume, Integer};
 use arrayvec::ArrayVec;
 use derive_more::Deref;
 use std::ops::Range;
@@ -60,7 +60,7 @@ impl<T: Clone + Accumulator> Evaluator<T> {
     /// The [`Position`]'s evaluation.
     pub fn evaluate(&self) -> Value {
         let phase = (self.occupied().len() - 1) / 4;
-        Value::saturate(self.acc.evaluate(phase))
+        self.acc.evaluate(phase).saturate()
     }
 
     /// The Static Exchange Evaluation ([SEE]) algorithm.

--- a/lib/nnue/feature.rs
+++ b/lib/nnue/feature.rs
@@ -11,7 +11,7 @@ impl Feature {
     #[inline(always)]
     pub fn index(&self, side: Color) -> u16 {
         let Feature(ks, p, s) = self.perspective(side);
-        s as u16 + 64 * (p.repr().min(10) as u16 + 11 * ks as u16)
+        s as u16 + 64 * (p.get().min(10) as u16 + 11 * ks as u16)
     }
 }
 

--- a/lib/nnue/value.rs
+++ b/lib/nnue/value.rs
@@ -18,6 +18,6 @@ pub type Value = Saturating<ValueRepr>;
 impl const Perspective for Value {
     #[inline(always)]
     fn flip(&self) -> Self {
-        Saturating::from_repr(-self.repr())
+        Self::new(-self.get())
     }
 }

--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -1,4 +1,4 @@
-use crate::util::{Binary, Bits, Integer, Saturating};
+use crate::util::{Assume, Binary, Bits, Integer, Saturating};
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -25,12 +25,12 @@ impl Binary for Depth {
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
-        Bits::new(self.get() as _)
+        self.convert().assume()
     }
 
     #[inline(always)]
     fn decode(bits: Self::Bits) -> Self {
-        Depth::new(bits.get() as _)
+        bits.convert().assume()
     }
 }
 

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -178,7 +178,7 @@ impl Engine {
 
         let score = match tpos {
             Some(t) => t.score().normalize(ply),
-            _ => pos.evaluate().cast(),
+            _ => pos.evaluate().saturate(),
         };
 
         let depth = match tpos {
@@ -275,7 +275,7 @@ impl Engine {
                 next.play(m);
 
                 if gain < 100 && !in_check && !next.is_check() {
-                    if let Some(d) = self.lmp(&next, m, alpha.cast(), depth, ply) {
+                    if let Some(d) = self.lmp(&next, m, alpha.saturate(), depth, ply) {
                         if d <= ply || -self.nw(&next, -alpha, d, ply + 1, ctrl)? <= alpha {
                             #[cfg(not(test))]
                             // The late move pruning heuristic is not exact.
@@ -386,7 +386,7 @@ mod tests {
         let score = match pos.outcome() {
             Some(o) if o.is_draw() => return Score::new(0),
             Some(_) => return Score::lower().normalize(ply),
-            None => pos.evaluate().cast(),
+            None => pos.evaluate().saturate(),
         };
 
         if ply >= Ply::MAX {
@@ -517,7 +517,7 @@ mod tests {
     ) {
         assert_eq!(
             e.pvs(&pos, b, d, Ply::upper(), &Control::default()),
-            Ok(Pv::new(pos.evaluate().cast(), None))
+            Ok(Pv::new(pos.evaluate().saturate(), None))
         );
     }
 

--- a/lib/search/killers.rs
+++ b/lib/search/killers.rs
@@ -1,5 +1,5 @@
 use crate::chess::{Color, Move};
-use crate::search::Ply;
+use crate::{search::Ply, util::Integer};
 
 /// A set of [killer moves] indexed by [`Ply`] and side to move.
 ///
@@ -18,7 +18,7 @@ impl<const P: usize> Killers<P> {
     /// Adds a killer move to the set at a given ply for a given side to move.
     #[inline(always)]
     pub fn insert(&mut self, ply: Ply, side: Color, m: Move) {
-        if let Some(ks) = self.0.get_mut(ply.get() as usize) {
+        if let Some(ks) = self.0.get_mut(ply.cast::<usize>()) {
             let [first, last] = &mut ks[side as usize];
             if *first != Some(m) {
                 *last = *first;
@@ -31,7 +31,7 @@ impl<const P: usize> Killers<P> {
     #[inline(always)]
     pub fn contains(&self, ply: Ply, side: Color, m: Move) -> bool {
         self.0
-            .get(ply.get() as usize)
+            .get(ply.cast::<usize>())
             .is_some_and(|ks| ks[side as usize].contains(&Some(m)))
     }
 }

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -22,9 +22,9 @@ impl Score {
     /// Negative number of plies means the opponent is mating.
     pub fn mate(&self) -> Option<Ply> {
         if *self <= Score::lower() - Ply::MIN {
-            Some((Score::lower() - *self).cast())
+            Some((Score::lower() - *self).saturate())
         } else if *self >= Score::upper() - Ply::MAX {
-            Some((Score::upper() - *self).cast())
+            Some((Score::upper() - *self).saturate())
         } else {
             None
         }
@@ -45,7 +45,7 @@ impl Score {
 impl const Perspective for Score {
     #[inline(always)]
     fn flip(&self) -> Self {
-        Saturating::from_repr(-self.repr())
+        Self::new(-self.get())
     }
 }
 
@@ -54,12 +54,12 @@ impl Binary for Score {
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
-        Bits::new((self.get() - Score::lower().get()) as _)
+        Bits::new((self.get() - Self::lower().get()).cast())
     }
 
     #[inline(always)]
     fn decode(bits: Self::Bits) -> Self {
-        Self::lower() + bits.get() as i16
+        Self::lower() + bits.cast::<i16>()
     }
 }
 

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Move, Zobrist};
 use crate::search::{Depth, HashSize, Score};
-use crate::util::{Binary, Bits, Integer};
+use crate::util::{Assume, Binary, Bits, Integer};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{mem::size_of, ops::RangeInclusive};
 
@@ -30,12 +30,12 @@ impl Binary for TranspositionKind {
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
-        Bits::new(*self as _)
+        self.convert().assume()
     }
 
     #[inline(always)]
     fn decode(bits: Self::Bits) -> Self {
-        TranspositionKind::from_repr(bits.get())
+        bits.convert().assume()
     }
 }
 
@@ -152,7 +152,7 @@ pub struct TranspositionTable {
 
             for (pos, t) in ts {
                 let key = pos.zobrist();
-                let idx = key.slice(..cache.len().trailing_zeros()).get() as usize;
+                let idx = key.slice(..cache.len().trailing_zeros()).cast::<usize>();
                 let sig = key.slice(cache.len().trailing_zeros()..).pop();
                 *cache[idx].get_mut() = Some(SignedTransposition(sig, t.encode())).encode().get();
             }
@@ -190,7 +190,7 @@ impl TranspositionTable {
     }
 
     fn index_of(&self, key: Zobrist) -> usize {
-        key.slice(..self.capacity().trailing_zeros()).get() as _
+        key.slice(..self.capacity().trailing_zeros()).cast()
     }
 
     /// Loads the [`Transposition`] from the slot associated with `key`.

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Color, Move, Perspective, Position};
 use crate::nnue::Evaluator;
-use crate::search::{Depth, Engine, HashSize, Limits, Options, Score, ThreadCount};
+use crate::search::{Engine, HashSize, Limits, Options, Score, ThreadCount};
 use crate::util::{Assume, Integer};
 use arrayvec::ArrayString;
 use derive_more::{Deref, Display};
@@ -165,7 +165,7 @@ impl Uci {
 
             ["go", "depth", depth] => {
                 match depth.parse::<u8>() {
-                    Ok(d) => self.go(Depth::saturate(d).into(), out)?,
+                    Ok(d) => self.go(Limits::Depth(d.saturate()), out)?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -197,7 +197,7 @@ impl Uci {
 
             ["bench", "depth", depth] => {
                 match depth.parse::<u8>() {
-                    Ok(d) => self.bench(Depth::saturate(d).into(), out)?,
+                    Ok(d) => self.bench(Limits::Depth(d.saturate()), out)?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -216,9 +216,9 @@ impl Uci {
             ["eval"] => {
                 let turn = self.position.turn();
                 let pos = Evaluator::new(self.position.clone());
-                let material: Score = pos.material().evaluate().perspective(turn).cast();
-                let positional: Score = pos.positional().evaluate().perspective(turn).cast();
-                let evaluation: Score = pos.evaluate().perspective(turn).cast();
+                let material: Score = pos.material().evaluate().perspective(turn).saturate();
+                let positional: Score = pos.positional().evaluate().perspective(turn).saturate();
+                let evaluation: Score = pos.evaluate().perspective(turn).saturate();
 
                 writeln!(
                     out,
@@ -322,6 +322,7 @@ impl Uci {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::search::Depth;
     use proptest::sample::Selector;
     use std::str;
     use test_strategy::proptest;

--- a/lib/util/assume.rs
+++ b/lib/util/assume.rs
@@ -47,3 +47,21 @@ impl<T: ~const Destruct, E: ~const Destruct> const Assume for Result<T, E> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[test]
+    #[should_panic]
+    fn assuming_none_panics() {
+        None.assume()
+    }
+
+    #[proptest]
+    #[should_panic]
+    fn assuming_err_panics(i: i8) {
+        Err(i).assume()
+    }
+}

--- a/lib/util/binary.rs
+++ b/lib/util/binary.rs
@@ -1,5 +1,4 @@
-use crate::util::Bits;
-use num_traits::{PrimInt, Unsigned};
+use crate::util::{Bits, Unsigned};
 use std::fmt::Debug;
 
 /// Trait for types that can be encoded to binary.
@@ -14,7 +13,7 @@ pub trait Binary: Sized {
     fn decode(bits: Self::Bits) -> Self;
 }
 
-impl<T: PrimInt + Unsigned, const W: u32> Binary for Bits<T, W> {
+impl<T: Unsigned, const W: u32> Binary for Bits<T, W> {
     type Bits = Self;
 
     #[inline(always)]

--- a/lib/util/integer.rs
+++ b/lib/util/integer.rs
@@ -1,5 +1,6 @@
-use num_traits::PrimInt;
-use std::{iter::Map, mem::transmute_copy, ops::RangeInclusive};
+use std::mem::{size_of, transmute_copy};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+use std::{cmp::Ordering, iter::Map, marker::Destruct, ops::*};
 
 /// Trait for types that can be represented by a contiguous range of primitive integers.
 ///
@@ -7,9 +8,9 @@ use std::{iter::Map, mem::transmute_copy, ops::RangeInclusive};
 ///
 /// Must only be implemented for types that can be safely transmuted to and from [`Integer::Repr`].
 #[const_trait]
-pub unsafe trait Integer: Copy {
+pub unsafe trait Integer: ~const Destruct + Copy {
     /// The equivalent primitive integer type.
-    type Repr: PrimInt;
+    type Repr: ~const Primitive;
 
     /// The minimum repr.
     const MIN: Self::Repr;
@@ -20,24 +21,53 @@ pub unsafe trait Integer: Copy {
     /// The minimum value.
     #[inline(always)]
     fn lower() -> Self {
-        Self::from_repr(Self::MIN)
+        Self::new(Self::MIN)
     }
 
     /// The maximum value.
     #[inline(always)]
     fn upper() -> Self {
-        Self::from_repr(Self::MAX)
-    }
-
-    /// Casts to [`Integer::Repr`].
-    fn repr(&self) -> Self::Repr {
-        unsafe { transmute_copy(self) }
+        Self::new(Self::MAX)
     }
 
     /// Casts from [`Integer::Repr`].
     #[inline(always)]
-    fn from_repr(i: Self::Repr) -> Self {
+    fn new(i: Self::Repr) -> Self {
+        debug_assert!(Self::in_range(i));
         unsafe { transmute_copy(&i) }
+    }
+
+    /// Casts to [`Integer::Repr`].
+    #[inline(always)]
+    fn get(self) -> Self::Repr {
+        unsafe { transmute_copy(&self) }
+    }
+
+    /// Casts to a [`Primitive`].
+    ///
+    /// This is equivalent to the operator `as`.
+    #[inline(always)]
+    fn cast<I: ~const Primitive>(self) -> I {
+        self.get().cast()
+    }
+
+    /// Converts to another [`Integer`] if possible without data loss.
+    #[inline(always)]
+    fn convert<I: ~const Integer>(self) -> Option<I> {
+        self.get().convert()
+    }
+
+    /// Converts to another [`Integer`] with saturation.
+    #[inline(always)]
+    fn saturate<I: ~const Integer>(self) -> I {
+        self.get().saturate()
+    }
+
+    /// Whether a value is in the range `(Self::MIN..=Self::MAX)`.
+    #[inline(always)]
+    fn in_range(i: Self::Repr) -> bool {
+        !matches!(Self::MIN.ordering(i), Ordering::Greater)
+            && !matches!(Self::MAX.ordering(i), Ordering::Less)
     }
 
     /// An iterator over all values in the range [`Integer::MIN`]..=[`Integer::MAX`].
@@ -47,9 +77,173 @@ pub unsafe trait Integer: Copy {
     where
         RangeInclusive<Self::Repr>: Iterator<Item = Self::Repr>,
     {
-        (Self::MIN..=Self::MAX).map(Self::from_repr)
+        (Self::MIN..=Self::MAX).map(Self::new)
     }
 }
+
+/// Trait for primitive integer types.
+#[const_trait]
+pub trait Primitive:
+    ~const Integer<Repr = Self>
+    + Eq
+    + PartialEq
+    + Ord
+    + PartialOrd
+    + Add<Output = Self>
+    + AddAssign
+    + Sub<Output = Self>
+    + SubAssign
+    + Mul<Output = Self>
+    + MulAssign
+    + Div<Output = Self>
+    + DivAssign
+    + BitAnd<Output = Self>
+    + BitAndAssign
+    + BitOr<Output = Self>
+    + BitOrAssign
+    + BitXor<Output = Self>
+    + BitXorAssign
+    + Shl<Output = Self>
+    + ShlAssign
+    + Shr<Output = Self>
+    + ShrAssign
+    + Not<Output = Self>
+{
+    /// The bit width.
+    const BITS: u32;
+
+    /// The constant `0`.
+    fn zero() -> Self {
+        Self::ones(0)
+    }
+
+    /// A value with `n` trailing `1`s.
+    fn ones(n: u32) -> Self;
+
+    /// Compares this primitive to another.
+    fn ordering(self, other: Self) -> Ordering;
+}
+
+/// Marker trait for signed primitive integers.
+pub trait Signed: Primitive {}
+
+/// Marker trait for unsigned primitive integers.
+pub trait Unsigned: Primitive {}
+
+macro_rules! impl_integer_for_non_zero {
+    ($nz: ty, $repr: ty) => {
+        unsafe impl const Integer for $nz {
+            type Repr = $repr;
+            const MIN: Self::Repr = <$nz>::MIN.get();
+            const MAX: Self::Repr = <$nz>::MAX.get();
+        }
+    };
+}
+
+impl_integer_for_non_zero!(NonZeroU8, u8);
+impl_integer_for_non_zero!(NonZeroU16, u16);
+impl_integer_for_non_zero!(NonZeroU32, u32);
+impl_integer_for_non_zero!(NonZeroU64, u64);
+impl_integer_for_non_zero!(NonZeroUsize, usize);
+
+macro_rules! impl_primitive_for {
+    ($i: ty, $m: ty) => {
+        impl $m for $i {}
+
+        impl const Primitive for $i {
+            const BITS: u32 = <$i>::BITS;
+
+            #[inline(always)]
+            fn ones(n: u32) -> Self {
+                match n {
+                    0 => 0,
+                    n => Self::MAX >> (Self::BITS - n),
+                }
+            }
+
+            #[inline(always)]
+            fn ordering(self, other: Self) -> Ordering {
+                if self > other {
+                    Ordering::Greater
+                } else if self < other {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            }
+        }
+
+        unsafe impl const Integer for $i {
+            type Repr = $i;
+
+            const MIN: Self::Repr = <$i>::MIN;
+            const MAX: Self::Repr = <$i>::MAX;
+
+            #[inline(always)]
+            fn cast<I: ~const Primitive>(self) -> I {
+                if size_of::<I>() <= size_of::<Self>() {
+                    unsafe { transmute_copy(&self) }
+                } else {
+                    match size_of::<I>() {
+                        2 => (self as i16).cast(),
+                        4 => (self as i32).cast(),
+                        8 => (self as i64).cast(),
+                        16 => (self as i128).cast(),
+
+                        #[cfg(not(debug_assertions))]
+                        _ => unsafe { std::hint::unreachable_unchecked() },
+
+                        #[cfg(debug_assertions)]
+                        _ => unreachable!(),
+                    }
+                }
+            }
+
+            #[inline(always)]
+            fn convert<I: ~const Integer>(self) -> Option<I> {
+                let i = self.cast();
+
+                if I::in_range(i)
+                    && i.cast::<Self>() == self
+                    && i.ordering(I::Repr::zero()) as i8 == self.ordering(Self::zero()) as i8
+                {
+                    Some(I::new(i))
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            fn saturate<I: ~const Integer>(self) -> I {
+                let min = match I::MIN.convert() {
+                    None => Self::MIN,
+                    Some(i) => i,
+                };
+
+                let max = match I::MAX.convert() {
+                    None => Self::MAX,
+                    Some(i) => i,
+                };
+
+                I::new(self.clamp(min, max).cast::<I::Repr>())
+            }
+        }
+    };
+}
+
+impl_primitive_for!(i8, Signed);
+impl_primitive_for!(i16, Signed);
+impl_primitive_for!(i32, Signed);
+impl_primitive_for!(i64, Signed);
+impl_primitive_for!(i128, Signed);
+impl_primitive_for!(isize, Signed);
+
+impl_primitive_for!(u8, Unsigned);
+impl_primitive_for!(u16, Unsigned);
+impl_primitive_for!(u32, Unsigned);
+impl_primitive_for!(u64, Unsigned);
+impl_primitive_for!(u128, Unsigned);
+impl_primitive_for!(usize, Unsigned);
 
 #[cfg(test)]
 mod tests {
@@ -77,23 +271,59 @@ mod tests {
     }
 
     #[proptest]
-    fn can_be_cast_to_integer(d: Digit) {
-        assert_eq!(Digit::from_repr(d.repr()), d);
+    fn integer_can_be_cast_from_repr(#[strategy(1u16..10)] i: u16) {
+        assert_eq!(Digit::new(i).get(), i);
     }
 
     #[proptest]
-
-    fn can_be_cast_from_integer(#[strategy(1u16..10)] i: u16) {
-        assert_eq!(Digit::from_repr(i).repr(), i);
+    #[should_panic]
+    fn integer_construction_panics_if_repr_smaller_than_min(#[strategy(..1u16)] i: u16) {
+        Digit::new(i);
     }
 
     #[proptest]
-    fn is_ordered_by_repr(a: Digit, b: Digit) {
-        assert_eq!(a < b, a.repr() < b.repr());
+    #[should_panic]
+    fn integer_construction_panics_if_repr_greater_than_max(#[strategy(10u16..)] i: u16) {
+        Digit::new(i);
     }
 
     #[proptest]
-    fn can_be_iterated_in_order() {
+    fn integer_can_be_cast_to_repr(d: Digit) {
+        assert_eq!(Digit::new(d.get()), d);
+    }
+
+    #[proptest]
+    fn integer_can_be_cast_to_primitive(d: Digit) {
+        assert_eq!(d.cast::<i8>(), d.get() as i8);
+    }
+
+    #[proptest]
+    fn integer_can_be_converted_to_another_integer_within_bounds(#[strategy(1i8..10)] i: i8) {
+        assert_eq!(i.convert(), Some(Digit::new(i as u16)));
+    }
+
+    #[proptest]
+    fn integer_conversion_fails_if_smaller_than_min(#[strategy(..1i8)] i: i8) {
+        assert_eq!(i.convert::<Digit>(), None);
+    }
+
+    #[proptest]
+    fn integer_conversion_fails_if_greater_than_max(#[strategy(10i8..)] i: i8) {
+        assert_eq!(i.convert::<Digit>(), None);
+    }
+
+    #[proptest]
+    fn integer_can_be_converted_to_another_integer_with_saturation(i: u8) {
+        assert_eq!(i.saturate::<Digit>(), Digit::new(i.clamp(1, 9).into()));
+    }
+
+    #[proptest]
+    fn integer_is_always_in_range(d: Digit) {
+        assert!(Digit::in_range(d.get()));
+    }
+
+    #[proptest]
+    fn integer_can_be_iterated_in_order() {
         assert_eq!(
             Vec::from_iter(Digit::iter()),
             vec![
@@ -108,5 +338,55 @@ mod tests {
                 Digit::Nine,
             ],
         );
+    }
+
+    #[proptest]
+    fn integer_is_eq_by_repr(a: Digit, b: Digit) {
+        assert_eq!(a == b, a.get() == b.get());
+    }
+
+    #[proptest]
+    fn integer_is_ord_by_repr(a: Digit, b: Digit) {
+        assert_eq!(a < b, a.get() < b.get());
+    }
+
+    #[proptest]
+    fn primitive_can_be_constructed_with_trailing_ones(#[strategy(..=64u32)] n: u32) {
+        assert_eq!(u64::ones(n).trailing_ones(), n);
+    }
+
+    #[proptest]
+    fn primitive_can_be_cast(i: i16) {
+        assert_eq!(i.cast::<u8>(), i as u8);
+        assert_eq!(i.cast::<i8>(), i as i8);
+
+        assert_eq!(i.cast::<u32>(), i as u32);
+        assert_eq!(i.cast::<i32>(), i as i32);
+
+        assert_eq!(i.cast::<u8>().cast::<i32>(), i as u8 as i32);
+        assert_eq!(i.cast::<i8>().cast::<u32>(), i as i8 as u32);
+
+        assert_eq!(i.cast::<u32>().cast::<i8>(), i as u32 as i8);
+        assert_eq!(i.cast::<i32>().cast::<u8>(), i as i32 as u8);
+    }
+
+    #[proptest]
+    fn primitive_can_be_converted(#[strategy(256u16..)] i: u16) {
+        assert_eq!(i.convert::<u8>(), None);
+        assert_eq!(i.convert::<i8>(), None);
+
+        assert_eq!(i.convert::<u32>(), Some(i.into()));
+        assert_eq!(i.convert::<i32>(), Some(i.into()));
+    }
+
+    #[proptest]
+    fn integer_can_be_converted_to_another_primitive_with_saturation(i: u16) {
+        assert_eq!(i.saturate::<i8>(), i.min(i8::MAX as _) as _);
+        assert_eq!(i.saturate::<u32>(), i.into());
+    }
+
+    #[proptest]
+    fn primitive_has_total_order(i: i16, j: i16) {
+        assert_eq!(i.ordering(j), i.cmp(&j));
     }
 }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=-5 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 6 -ratinginterval 10 -resultformat wide -recover -engine conf=dev -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 480 - 435 - 1205  [0.511] 2120
...      dev playing White: 304 - 170 - 586  [0.563] 1060
...      dev playing Black: 176 - 265 - 619  [0.458] 1060
...      White vs Black: 569 - 346 - 1205  [0.553] 2120
Elo difference: 7.4 +/- 9.7, LOS: 93.2 %, DrawRatio: 56.8 %
SPRT: llr 3 (102.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     65     58     61     66     67     55     53     47     46     62     47     59     60     58     52    856
   Score   7643   6991   7517   8043   7748   7650   6969   6548   5949   7356   6304   6940   6694   7113   6582 106047
Score(%)   89.9   87.4   87.4   90.4   91.2   95.6   85.0   81.8   83.8   93.1   90.1   93.8   89.3   90.0   90.2   89.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.6%, "Re-Capturing"
2. STS 12, 93.8%, "Center Control"
3. STS 10, 93.1%, "Simplification"
4. STS 05, 91.2%, "Bishop vs Knight"
5. STS 04, 90.4%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 08, 81.8%, "Advancement of f/g/h Pawns"
2. STS 09, 83.8%, "Advancement of a/b/c Pawns"
3. STS 07, 85.0%, "Offer of Simplification"
4. STS 02, 87.4%, "Open Files and Diagonals"
5. STS 03, 87.4%, "Knight Outposts"
```