### PR TITLE
Avoid unnecessary memcpy

### DIFF
--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -1,43 +1,37 @@
+use crate::chess::Color;
+
 /// Trait for transformer accumulators.
 pub trait Accumulator {
-    /// Flips this accumulator's perspective.
-    fn flip(&mut self);
-
     /// Refreshes this accumulator.
-    fn refresh(&mut self, us: &[u16], them: &[u16]);
+    fn refresh(&mut self, white: &[u16], black: &[u16]);
 
     /// Updates this accumulator by adding features.
-    fn add(&mut self, us: u16, them: u16);
+    fn add(&mut self, white: u16, black: u16);
 
     /// Updates this accumulator by removing features.
-    fn remove(&mut self, us: u16, them: u16);
+    fn remove(&mut self, white: u16, black: u16);
 
     /// Evaluates this accumulator.
-    fn evaluate(&self, phase: usize) -> i32;
+    fn evaluate(&self, turn: Color, phase: usize) -> i32;
 }
 
 impl<T: Accumulator, U: Accumulator> Accumulator for (T, U) {
-    fn flip(&mut self) {
-        self.0.flip();
-        self.1.flip();
+    fn refresh(&mut self, white: &[u16], black: &[u16]) {
+        self.0.refresh(white, black);
+        self.1.refresh(white, black);
     }
 
-    fn refresh(&mut self, us: &[u16], them: &[u16]) {
-        self.0.refresh(us, them);
-        self.1.refresh(us, them);
+    fn add(&mut self, white: u16, black: u16) {
+        self.0.add(white, black);
+        self.1.add(white, black);
     }
 
-    fn add(&mut self, us: u16, them: u16) {
-        self.0.add(us, them);
-        self.1.add(us, them);
+    fn remove(&mut self, white: u16, black: u16) {
+        self.0.remove(white, black);
+        self.1.remove(white, black);
     }
 
-    fn remove(&mut self, us: u16, them: u16) {
-        self.0.remove(us, them);
-        self.1.remove(us, them);
-    }
-
-    fn evaluate(&self, phase: usize) -> i32 {
-        self.0.evaluate(phase) + self.1.evaluate(phase)
+    fn evaluate(&self, turn: Color, phase: usize) -> i32 {
+        self.0.evaluate(turn, phase) + self.1.evaluate(turn, phase)
     }
 }

--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -7,33 +7,32 @@ use derive_more::Constructor;
 pub struct Hidden<const N: usize> {
     #[cfg_attr(test, map(|b: i8| i32::from(b)))]
     pub(super) bias: i32,
-    pub(super) weight: AlignTo64<[i8; N]>,
+    pub(super) weight: AlignTo64<[[i8; N]; 2]>,
 }
 
 impl<const N: usize> Hidden<N> {
     #[doc(hidden)]
     #[cfg(target_feature = "avx2")]
-    pub unsafe fn avx2(&self, input: &AlignTo64<[i16; N]>) -> i32 {
+    pub unsafe fn avx2(&self, input: [&[i16; N]; 2]) -> i32 {
         #[cfg(target_arch = "x86_64")]
         use std::arch::x86_64::*;
 
         debug_assert!(N % 32 == 0);
-        let a = self.weight.array_chunks::<32>();
-        let x = input.array_chunks::<32>();
         let mut y = _mm256_setzero_si256();
-
-        for (a, x) in Iterator::zip(a, x) {
-            debug_assert_eq!(x[..16].as_ptr() as usize % 32, 0);
-            let p = _mm256_load_si256(x[..16].as_ptr() as _);
-            debug_assert_eq!(x[16..].as_ptr() as usize % 32, 0);
-            let q = _mm256_load_si256(x[16..].as_ptr() as _);
-            let r = _mm256_packs_epi16(p, q);
-            let s = _mm256_max_epi8(r, _mm256_setzero_si256());
-            let t = _mm256_permute4x64_epi64(s, 0b11011000);
-            debug_assert_eq!(a.as_ptr() as usize % 32, 0);
-            let u = _mm256_maddubs_epi16(t, _mm256_load_si256(a.as_ptr() as _));
-            let v = _mm256_madd_epi16(u, _mm256_set1_epi16(1));
-            y = _mm256_add_epi32(y, v);
+        for (w, i) in self.weight.iter().zip(input) {
+            for (a, x) in Iterator::zip(w.array_chunks::<32>(), i.array_chunks::<32>()) {
+                debug_assert_eq!(x[..16].as_ptr() as usize % 32, 0);
+                let p = _mm256_load_si256(x[..16].as_ptr() as _);
+                debug_assert_eq!(x[16..].as_ptr() as usize % 32, 0);
+                let q = _mm256_load_si256(x[16..].as_ptr() as _);
+                let r = _mm256_packs_epi16(p, q);
+                let s = _mm256_max_epi8(r, _mm256_setzero_si256());
+                let t = _mm256_permute4x64_epi64(s, 0b11011000);
+                debug_assert_eq!(a.as_ptr() as usize % 32, 0);
+                let u = _mm256_maddubs_epi16(t, _mm256_load_si256(a.as_ptr() as _));
+                let v = _mm256_madd_epi16(u, _mm256_set1_epi16(1));
+                y = _mm256_add_epi32(y, v);
+            }
         }
 
         // https://stackoverflow.com/a/60109639
@@ -49,26 +48,25 @@ impl<const N: usize> Hidden<N> {
 
     #[doc(hidden)]
     #[cfg(all(target_feature = "sse4.1", target_feature = "ssse3"))]
-    pub unsafe fn sse(&self, input: &AlignTo64<[i16; N]>) -> i32 {
+    pub unsafe fn sse(&self, input: [&[i16; N]; 2]) -> i32 {
         #[cfg(target_arch = "x86_64")]
         use std::arch::x86_64::*;
 
         debug_assert!(N % 16 == 0);
-        let a = self.weight.array_chunks::<16>();
-        let x = input.array_chunks::<16>();
         let mut y = _mm_setzero_si128();
-
-        for (a, x) in Iterator::zip(a, x) {
-            debug_assert_eq!(x[..8].as_ptr() as usize % 16, 0);
-            let p = _mm_load_si128(x[..8].as_ptr() as _);
-            debug_assert_eq!(x[8..].as_ptr() as usize % 16, 0);
-            let q = _mm_load_si128(x[8..].as_ptr() as _);
-            let r = _mm_packs_epi16(p, q);
-            let s = _mm_max_epi8(r, _mm_setzero_si128());
-            debug_assert_eq!(a.as_ptr() as usize % 16, 0);
-            let t = _mm_maddubs_epi16(s, _mm_load_si128(a.as_ptr() as _));
-            let u = _mm_madd_epi16(t, _mm_set1_epi16(1));
-            y = _mm_add_epi32(y, u);
+        for (w, i) in self.weight.iter().zip(input) {
+            for (a, x) in Iterator::zip(w.array_chunks::<16>(), i.array_chunks::<16>()) {
+                debug_assert_eq!(x[..8].as_ptr() as usize % 16, 0);
+                let p = _mm_load_si128(x[..8].as_ptr() as _);
+                debug_assert_eq!(x[8..].as_ptr() as usize % 16, 0);
+                let q = _mm_load_si128(x[8..].as_ptr() as _);
+                let r = _mm_packs_epi16(p, q);
+                let s = _mm_max_epi8(r, _mm_setzero_si128());
+                debug_assert_eq!(a.as_ptr() as usize % 16, 0);
+                let t = _mm_maddubs_epi16(s, _mm_load_si128(a.as_ptr() as _));
+                let u = _mm_madd_epi16(t, _mm_set1_epi16(1));
+                y = _mm_add_epi32(y, u);
+            }
         }
 
         // https://stackoverflow.com/a/35270026
@@ -80,10 +78,12 @@ impl<const N: usize> Hidden<N> {
     }
 
     #[doc(hidden)]
-    pub fn scalar(&self, input: &[i16; N]) -> i32 {
+    pub fn scalar(&self, input: [&[i16; N]; 2]) -> i32 {
         let mut y = self.bias;
-        for (&a, &x) in self.weight.iter().zip(input) {
-            y += a as i32 * x.clamp(0, i8::MAX as _) as i32;
+        for (w, i) in self.weight.iter().zip(input) {
+            for (&a, &x) in Iterator::zip(w.iter(), i.iter()) {
+                y += a as i32 * x.clamp(0, i8::MAX as _) as i32;
+            }
         }
 
         y
@@ -92,7 +92,7 @@ impl<const N: usize> Hidden<N> {
 
 impl<const N: usize> Hidden<N> {
     /// Transforms the accumulator.
-    pub fn forward(&self, input: &AlignTo64<[i16; N]>) -> i32 {
+    pub fn forward(&self, input: [&[i16; N]; 2]) -> i32 {
         #[cfg(target_feature = "avx2")]
         unsafe {
             self.avx2(input)
@@ -117,25 +117,23 @@ mod tests {
 
     #[cfg(target_feature = "avx2")]
     #[proptest]
-    fn uses_avx(o: Hidden<64>, i: AlignTo64<[i16; 64]>) {
-        assert_eq!(unsafe { o.avx2(&i) }, o.scalar(&i));
+    fn uses_avx(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
+        assert_eq!(unsafe { o.avx2([&i[0], &i[1]]) }, o.scalar([&i[0], &i[1]]));
     }
 
     #[cfg(all(target_feature = "sse4.1", target_feature = "ssse3"))]
     #[proptest]
-    fn uses_sse(o: Hidden<64>, i: AlignTo64<[i16; 64]>) {
-        assert_eq!(unsafe { o.sse(&i) }, o.scalar(&i));
+    fn uses_sse(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
+        assert_eq!(unsafe { o.sse([&i[0], &i[1]]) }, o.scalar([&i[0], &i[1]]));
     }
 
     #[proptest]
-    fn clips_and_multiplies_by_weight_and_adds_bias(o: Hidden<64>, i: AlignTo64<[i16; 64]>) {
+    fn clips_and_multiplies_by_weight_and_adds_bias(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
         assert_eq!(
-            o.forward(&i),
+            o.forward([&i[0], &i[1]]),
             o.bias
-                + o.weight
-                    .iter()
-                    .zip(i)
-                    .map(|(&a, x)| a as i32 * x.clamp(0, i8::MAX as _) as i32)
+                + Iterator::zip(o.weight.iter().flatten(), i.iter().flatten())
+                    .map(|(&a, &x)| a as i32 * x.clamp(0, i8::MAX as _) as i32)
                     .sum::<i32>()
         );
     }

--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -14,66 +14,125 @@ impl<const N: usize> Hidden<N> {
     #[doc(hidden)]
     #[cfg(target_feature = "avx2")]
     pub unsafe fn avx2(&self, input: [&[i16; N]; 2]) -> i32 {
-        #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::*;
+        const { assert!(N % 128 == 0) };
 
-        debug_assert!(N % 32 == 0);
+        use std::{arch::x86_64::*, mem::transmute};
+
         let mut y = _mm256_setzero_si256();
         for (w, i) in self.weight.iter().zip(input) {
-            for (a, x) in Iterator::zip(w.array_chunks::<32>(), i.array_chunks::<32>()) {
-                debug_assert_eq!(x[..16].as_ptr() as usize % 32, 0);
-                let p = _mm256_load_si256(x[..16].as_ptr() as _);
-                debug_assert_eq!(x[16..].as_ptr() as usize % 32, 0);
-                let q = _mm256_load_si256(x[16..].as_ptr() as _);
-                let r = _mm256_packs_epi16(p, q);
-                let s = _mm256_max_epi8(r, _mm256_setzero_si256());
-                let t = _mm256_permute4x64_epi64(s, 0b11011000);
-                debug_assert_eq!(a.as_ptr() as usize % 32, 0);
-                let u = _mm256_maddubs_epi16(t, _mm256_load_si256(a.as_ptr() as _));
-                let v = _mm256_madd_epi16(u, _mm256_set1_epi16(1));
-                y = _mm256_add_epi32(y, v);
+            debug_assert_eq!(w.as_ptr() as usize % 32, 0);
+            debug_assert_eq!(i.as_ptr() as usize % 32, 0);
+
+            for (a, x) in Iterator::zip(w.array_chunks::<128>(), i.array_chunks::<128>()) {
+                let a = transmute::<&[i8; 128], &[[i8; 32]; 4]>(a);
+                let x = transmute::<&[i16; 128], &[[i16; 32]; 4]>(x);
+
+                let p0 = _mm256_load_si256(x[0][..16].as_ptr() as _);
+                let q0 = _mm256_load_si256(x[0][16..].as_ptr() as _);
+                let p1 = _mm256_load_si256(x[1][..16].as_ptr() as _);
+                let q1 = _mm256_load_si256(x[1][16..].as_ptr() as _);
+                let p2 = _mm256_load_si256(x[2][..16].as_ptr() as _);
+                let q2 = _mm256_load_si256(x[2][16..].as_ptr() as _);
+                let p3 = _mm256_load_si256(x[3][..16].as_ptr() as _);
+                let q3 = _mm256_load_si256(x[3][16..].as_ptr() as _);
+
+                let r = _mm256_packs_epi16(p0, q0);
+                let r = _mm256_max_epi8(r, _mm256_setzero_si256());
+                let r = _mm256_permute4x64_epi64(r, 0b11011000);
+                let r = _mm256_maddubs_epi16(r, _mm256_load_si256(a[0].as_ptr() as _));
+                let r = _mm256_madd_epi16(r, _mm256_set1_epi16(1));
+                y = _mm256_add_epi32(y, r);
+
+                let r = _mm256_packs_epi16(p1, q1);
+                let r = _mm256_max_epi8(r, _mm256_setzero_si256());
+                let r = _mm256_permute4x64_epi64(r, 0b11011000);
+                let r = _mm256_maddubs_epi16(r, _mm256_load_si256(a[1].as_ptr() as _));
+                let r = _mm256_madd_epi16(r, _mm256_set1_epi16(1));
+                y = _mm256_add_epi32(y, r);
+
+                let r = _mm256_packs_epi16(p2, q2);
+                let r = _mm256_max_epi8(r, _mm256_setzero_si256());
+                let r = _mm256_permute4x64_epi64(r, 0b11011000);
+                let r = _mm256_maddubs_epi16(r, _mm256_load_si256(a[2].as_ptr() as _));
+                let r = _mm256_madd_epi16(r, _mm256_set1_epi16(1));
+                y = _mm256_add_epi32(y, r);
+
+                let r = _mm256_packs_epi16(p3, q3);
+                let r = _mm256_max_epi8(r, _mm256_setzero_si256());
+                let r = _mm256_permute4x64_epi64(r, 0b11011000);
+                let r = _mm256_maddubs_epi16(r, _mm256_load_si256(a[3].as_ptr() as _));
+                let r = _mm256_madd_epi16(r, _mm256_set1_epi16(1));
+                y = _mm256_add_epi32(y, r);
             }
         }
 
         // https://stackoverflow.com/a/60109639
-        let p = _mm256_castsi256_si128(y);
-        let q = _mm256_extracti128_si256(y, 1);
-        let r = _mm_add_epi32(p, q);
+        let r = _mm256_castsi256_si128(y);
+        let s = _mm256_extracti128_si256(y, 1);
+        let r = _mm_add_epi32(r, s);
         let s = _mm_unpackhi_epi64(r, r);
-        let t = _mm_add_epi32(s, r);
-        let u = _mm_shuffle_epi32(t, _MM_SHUFFLE(2, 3, 0, 1));
-        let v = _mm_add_epi32(t, u);
-        self.bias + _mm_cvtsi128_si32(v)
+        let r = _mm_add_epi32(r, s);
+        let s = _mm_shuffle_epi32(r, _MM_SHUFFLE(2, 3, 0, 1));
+        let r = _mm_add_epi32(r, s);
+        self.bias + _mm_cvtsi128_si32(r)
     }
 
     #[doc(hidden)]
     #[cfg(all(target_feature = "sse4.1", target_feature = "ssse3"))]
     pub unsafe fn sse(&self, input: [&[i16; N]; 2]) -> i32 {
-        #[cfg(target_arch = "x86_64")]
-        use std::arch::x86_64::*;
+        const { assert!(N % 64 == 0) };
 
-        debug_assert!(N % 16 == 0);
+        use std::{arch::x86_64::*, mem::transmute};
+
         let mut y = _mm_setzero_si128();
         for (w, i) in self.weight.iter().zip(input) {
-            for (a, x) in Iterator::zip(w.array_chunks::<16>(), i.array_chunks::<16>()) {
-                debug_assert_eq!(x[..8].as_ptr() as usize % 16, 0);
-                let p = _mm_load_si128(x[..8].as_ptr() as _);
-                debug_assert_eq!(x[8..].as_ptr() as usize % 16, 0);
-                let q = _mm_load_si128(x[8..].as_ptr() as _);
-                let r = _mm_packs_epi16(p, q);
-                let s = _mm_max_epi8(r, _mm_setzero_si128());
-                debug_assert_eq!(a.as_ptr() as usize % 16, 0);
-                let t = _mm_maddubs_epi16(s, _mm_load_si128(a.as_ptr() as _));
-                let u = _mm_madd_epi16(t, _mm_set1_epi16(1));
-                y = _mm_add_epi32(y, u);
+            debug_assert_eq!(w.as_ptr() as usize % 16, 0);
+            debug_assert_eq!(i.as_ptr() as usize % 16, 0);
+
+            for (a, x) in Iterator::zip(w.array_chunks::<64>(), i.array_chunks::<64>()) {
+                let a = transmute::<&[i8; 64], &[[i8; 16]; 4]>(a);
+                let x = transmute::<&[i16; 64], &[[i16; 16]; 4]>(x);
+
+                let p0 = _mm_load_si128(x[0][..8].as_ptr() as _);
+                let q0 = _mm_load_si128(x[0][8..].as_ptr() as _);
+                let p1 = _mm_load_si128(x[1][..8].as_ptr() as _);
+                let q1 = _mm_load_si128(x[1][8..].as_ptr() as _);
+                let p2 = _mm_load_si128(x[2][..8].as_ptr() as _);
+                let q2 = _mm_load_si128(x[2][8..].as_ptr() as _);
+                let p3 = _mm_load_si128(x[3][..8].as_ptr() as _);
+                let q3 = _mm_load_si128(x[3][8..].as_ptr() as _);
+
+                let r = _mm_packs_epi16(p0, q0);
+                let r = _mm_max_epi8(r, _mm_setzero_si128());
+                let r = _mm_maddubs_epi16(r, _mm_load_si128(a[0].as_ptr() as _));
+                let r = _mm_madd_epi16(r, _mm_set1_epi16(1));
+                y = _mm_add_epi32(y, r);
+
+                let r = _mm_packs_epi16(p1, q1);
+                let r = _mm_max_epi8(r, _mm_setzero_si128());
+                let r = _mm_maddubs_epi16(r, _mm_load_si128(a[1].as_ptr() as _));
+                let r = _mm_madd_epi16(r, _mm_set1_epi16(1));
+                y = _mm_add_epi32(y, r);
+
+                let r = _mm_packs_epi16(p2, q2);
+                let r = _mm_max_epi8(r, _mm_setzero_si128());
+                let r = _mm_maddubs_epi16(r, _mm_load_si128(a[2].as_ptr() as _));
+                let r = _mm_madd_epi16(r, _mm_set1_epi16(1));
+                y = _mm_add_epi32(y, r);
+
+                let r = _mm_packs_epi16(p3, q3);
+                let r = _mm_max_epi8(r, _mm_setzero_si128());
+                let r = _mm_maddubs_epi16(r, _mm_load_si128(a[3].as_ptr() as _));
+                let r = _mm_madd_epi16(r, _mm_set1_epi16(1));
+                y = _mm_add_epi32(y, r);
             }
         }
 
         // https://stackoverflow.com/a/35270026
-        let p = _mm_shuffle_epi32(y, _MM_SHUFFLE(1, 0, 3, 2));
-        let q = _mm_add_epi32(p, y);
-        let r = _mm_shufflelo_epi16(q, _MM_SHUFFLE(1, 0, 3, 2));
-        let s = _mm_add_epi32(q, r);
+        let r = _mm_shuffle_epi32(y, _MM_SHUFFLE(1, 0, 3, 2));
+        let s = _mm_add_epi32(r, y);
+        let r = _mm_shufflelo_epi16(s, _MM_SHUFFLE(1, 0, 3, 2));
+        let s = _mm_add_epi32(r, s);
         self.bias + _mm_cvtsi128_si32(s)
     }
 
@@ -117,18 +176,18 @@ mod tests {
 
     #[cfg(target_feature = "avx2")]
     #[proptest]
-    fn uses_avx(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
+    fn uses_avx(o: Hidden<128>, i: AlignTo64<[[i16; 128]; 2]>) {
         assert_eq!(unsafe { o.avx2([&i[0], &i[1]]) }, o.scalar([&i[0], &i[1]]));
     }
 
     #[cfg(all(target_feature = "sse4.1", target_feature = "ssse3"))]
     #[proptest]
-    fn uses_sse(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
+    fn uses_sse(o: Hidden<128>, i: AlignTo64<[[i16; 128]; 2]>) {
         assert_eq!(unsafe { o.sse([&i[0], &i[1]]) }, o.scalar([&i[0], &i[1]]));
     }
 
     #[proptest]
-    fn clips_and_multiplies_by_weight_and_adds_bias(o: Hidden<32>, i: AlignTo64<[[i16; 32]; 2]>) {
+    fn clips_and_multiplies_by_weight_and_adds_bias(o: Hidden<128>, i: AlignTo64<[[i16; 128]; 2]>) {
         assert_eq!(
             o.forward([&i[0], &i[1]]),
             o.bias

--- a/lib/nnue/layer.rs
+++ b/lib/nnue/layer.rs
@@ -1,8 +1,0 @@
-/// Trait for types that can compose a neural network.
-pub trait Layer<Input: ?Sized> {
-    /// The transformed neurons.
-    type Output;
-
-    /// Transforms input neurons.
-    fn forward(&self, input: &Input) -> Self::Output;
-}

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -1,4 +1,4 @@
-use crate::nnue::{Accumulator, Layer, Nnue};
+use crate::nnue::{Accumulator, Nnue};
 use crate::util::AlignTo64;
 use std::mem::transmute;
 
@@ -44,7 +44,7 @@ impl Accumulator for Positional {
     #[inline(always)]
     fn evaluate(&self, phase: usize) -> i32 {
         let l1: &AlignTo64<[i16; Nnue::L1]> = unsafe { transmute(&self.0) };
-        Nnue::output(phase).forward(l1) / 16
+        Nnue::hidden(phase).forward(l1) / 16
     }
 }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Avalanche-2.1.0 -engine conf=Stash-35.0 -engine conf=Marvin-6.2 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -0       6    9000    2770    2779    3451   4495.5   50.0%   38.3% 
   1 Marvin-6.2                     68       9    3000    1081     498    1421   1791.5   59.7%   47.4% 
   2 Stash-35.0                    -16      10    3000     952    1088     960   1432.0   47.7%   32.0% 
   3 Avalanche-2.1.0               -51      10    3000     746    1184    1070   1281.0   42.7%   35.7%
```


### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:02s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     64     55     57     72     69     51     52     54     43     59     56     59     60     59     49    859
   Score   7633   6945   7247   8162   7822   7569   6905   6659   5819   7180   6575   6800   6763   7007   6470 105556
Score(%)   89.8   86.8   84.3   91.7   92.0   94.6   84.2   83.2   82.0   90.9   93.9   91.9   90.2   88.7   88.6   88.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.6%, "Re-Capturing"
2. STS 11, 93.9%, "Activity of the King"
3. STS 05, 92.0%, "Bishop vs Knight"
4. STS 12, 91.9%, "Center Control"
5. STS 04, 91.7%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 82.0%, "Advancement of a/b/c Pawns"
2. STS 08, 83.2%, "Advancement of f/g/h Pawns"
3. STS 07, 84.2%, "Offer of Simplification"
4. STS 03, 84.3%, "Knight Outposts"
5. STS 02, 86.8%, "Open Files and Diagonals"
```