### PR TITLE
Slightly reduce binary size

### DIFF
--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -4,7 +4,8 @@
     coverage_attribute,
     const_refs_to_cell,
     const_trait_impl,
-    effects
+    effects,
+    new_uninit
 )]
 
 /// Chess domain types.

--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -1,32 +1,29 @@
-use crate::chess::Color;
+use crate::{chess::Color, nnue::Feature};
 
 /// Trait for transformer accumulators.
-pub trait Accumulator {
-    /// Refreshes this accumulator.
-    fn refresh(&mut self, white: &[u16], black: &[u16]);
+pub trait Accumulator: Default {
+    /// The accumulator length.
+    const LEN: usize;
 
     /// Updates this accumulator by adding features.
-    fn add(&mut self, white: u16, black: u16);
+    fn add(&mut self, white: Feature, black: Feature);
 
     /// Updates this accumulator by removing features.
-    fn remove(&mut self, white: u16, black: u16);
+    fn remove(&mut self, white: Feature, black: Feature);
 
     /// Evaluates this accumulator.
     fn evaluate(&self, turn: Color, phase: usize) -> i32;
 }
 
 impl<T: Accumulator, U: Accumulator> Accumulator for (T, U) {
-    fn refresh(&mut self, white: &[u16], black: &[u16]) {
-        self.0.refresh(white, black);
-        self.1.refresh(white, black);
-    }
+    const LEN: usize = T::LEN + U::LEN;
 
-    fn add(&mut self, white: u16, black: u16) {
+    fn add(&mut self, white: Feature, black: Feature) {
         self.0.add(white, black);
         self.1.add(white, black);
     }
 
-    fn remove(&mut self, white: u16, black: u16) {
+    fn remove(&mut self, white: Feature, black: Feature) {
         self.0.remove(white, black);
         self.1.remove(white, black);
     }

--- a/lib/nnue/feature.rs
+++ b/lib/nnue/feature.rs
@@ -4,21 +4,24 @@ use crate::util::Integer;
 /// The HalfKAv2 feature.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct Feature(pub Square, pub Piece, pub Square);
+#[repr(transparent)]
+pub struct Feature(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as Integer>::Repr);
 
-impl Feature {
-    /// Feature's index for the given perspective.
-    #[inline(always)]
-    pub fn index(&self, side: Color) -> u16 {
-        let Feature(ks, p, sq) = self.perspective(side);
-        sq as u16 + 64 * (p.get().min(10) as u16 + 11 * ks as u16)
-    }
+unsafe impl const Integer for Feature {
+    type Repr = u16;
+    const MIN: Self::Repr = 0;
+    const MAX: Self::Repr = Self::LEN as Self::Repr - 1;
 }
 
-impl const Perspective for Feature {
+impl Feature {
+    /// The total number of different features.
+    pub const LEN: usize = 64 * 704;
+
+    /// Constructs feature from some perspective.
     #[inline(always)]
-    fn flip(&self) -> Self {
-        Feature(self.0.flip(), self.1.flip(), self.2.flip())
+    pub fn new(side: Color, ksq: Square, piece: Piece, sq: Square) -> Self {
+        let psq = sq.perspective(side) as u16 + 64 * piece.perspective(side).get().min(10) as u16;
+        Feature(psq + 704 * ksq.perspective(side) as u16)
     }
 }
 
@@ -27,14 +30,13 @@ mod tests {
     use super::*;
     use test_strategy::proptest;
 
-    #[proptest]
-    fn feature_index_is_unique_to_perspective(a: Feature, c: Color) {
-        assert_ne!(a.index(c), a.index(!c));
+    #[test]
+    fn len_counts_total_number_of_features() {
+        assert_eq!(Feature::LEN, Feature::iter().len());
     }
 
     #[proptest]
-    fn feature_has_a_mirror(a: Feature) {
-        assert_ne!(a.flip(), a);
-        assert_eq!(a.flip().flip(), a);
+    fn is_unique_to_perspective(c: Color, ksq: Square, p: Piece, sq: Square) {
+        assert_ne!(Feature::new(c, ksq, p, sq), Feature::new(!c, ksq, p, sq));
     }
 }

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -1,37 +1,33 @@
 use crate::chess::{Color, Mirror};
-use crate::nnue::{Accumulator, Nnue};
+use crate::nnue::{Accumulator, Feature, Nnue};
 use crate::util::AlignTo64;
 
 /// An accumulator for the feature transformer.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Positional(
-    #[cfg_attr(test, map(|vs: [[i8; Nnue::L1]; 2]| AlignTo64(vs.map(|v| v.map(i16::from)))))]
-    AlignTo64<[[i16; Nnue::L1]; 2]>,
+    #[cfg_attr(test, map(|vs: [[i8; Self::LEN]; 2]| AlignTo64(vs.map(|v| v.map(i16::from)))))]
+    AlignTo64<[[i16; Self::LEN]; 2]>,
 );
 
 impl Default for Positional {
     #[inline(always)]
     fn default() -> Self {
-        Positional(AlignTo64([[0; Nnue::L1]; 2]))
+        Positional(AlignTo64([Nnue::ft().fresh(); 2]))
     }
 }
 
 impl Accumulator for Positional {
-    #[inline(always)]
-    fn refresh(&mut self, white: &[u16], black: &[u16]) {
-        Nnue::ft().refresh(white, &mut self.0[0]);
-        Nnue::ft().refresh(black, &mut self.0[1]);
-    }
+    const LEN: usize = 512;
 
     #[inline(always)]
-    fn add(&mut self, white: u16, black: u16) {
+    fn add(&mut self, white: Feature, black: Feature) {
         Nnue::ft().add(white, &mut self.0[0]);
         Nnue::ft().add(black, &mut self.0[1]);
     }
 
     #[inline(always)]
-    fn remove(&mut self, white: u16, black: u16) {
+    fn remove(&mut self, white: Feature, black: Feature) {
         Nnue::ft().remove(white, &mut self.0[0]);
         Nnue::ft().remove(black, &mut self.0[1]);
     }
@@ -45,21 +41,14 @@ impl Accumulator for Positional {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chess::Color, nnue::Feature};
+    use crate::nnue::Feature;
     use test_strategy::proptest;
 
     #[proptest]
-    fn refresh_resets_accumulator(mut a: Positional, mut b: Positional, f: Feature, c: Color) {
-        a.refresh(&[f.index(c)], &[f.index(!c)]);
-        b.refresh(&[f.index(c)], &[f.index(!c)]);
-        assert_eq!(a, b);
-    }
-
-    #[proptest]
-    fn remove_reverses_add(a: Positional, f: Feature, c: Color) {
-        let mut b = a.clone();
-        b.add(f.index(c), f.index(!c));
-        b.remove(f.index(c), f.index(!c));
-        assert_eq!(a, b);
+    fn remove_reverses_add(e: Positional, w: Feature, b: Feature) {
+        let mut f = e.clone();
+        f.add(w, b);
+        f.remove(w, b);
+        assert_eq!(e, f);
     }
 }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=-5 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 410 - 406 - 1184  [0.501] 2000
...      dev playing White: 260 - 159 - 581  [0.550] 1000
...      dev playing Black: 150 - 247 - 603  [0.452] 1000
...      White vs Black: 507 - 309 - 1184  [0.549] 2000
Elo difference: 0.7 +/- 9.7, LOS: 55.6 %, DrawRatio: 59.2 %
SPRT: llr 0.282 (9.6%), lbound -2.94, ubound 2.94
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:02s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     53     62     63     65     53     56     52     51     60     49     60     59     56     49    854
   Score   7657   6812   7607   7667   7818   7674   7121   6555   6146   7211   6175   6983   6808   6936   6563 105733
Score(%)   90.1   85.2   88.5   86.1   92.0   95.9   86.8   81.9   86.6   91.3   88.2   94.4   90.8   87.8   89.9   89.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.9%, "Re-Capturing"
2. STS 12, 94.4%, "Center Control"
3. STS 05, 92.0%, "Bishop vs Knight"
4. STS 10, 91.3%, "Simplification"
5. STS 13, 90.8%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 08, 81.9%, "Advancement of f/g/h Pawns"
2. STS 02, 85.2%, "Open Files and Diagonals"
3. STS 04, 86.1%, "Square Vacancy"
4. STS 09, 86.6%, "Advancement of a/b/c Pawns"
5. STS 07, 86.8%, "Offer of Simplification"
```
