### PR TITLE
Slightly generated code quality

### DIFF
--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -11,6 +11,9 @@ pub trait Accumulator: Default {
     /// Updates this accumulator by removing features.
     fn remove(&mut self, white: Feature, black: Feature);
 
+    /// Updates this accumulator by replacing features.
+    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]);
+
     /// Evaluates this accumulator.
     fn evaluate(&self, turn: Color, phase: usize) -> i32;
 }
@@ -26,6 +29,11 @@ impl<T: Accumulator, U: Accumulator> Accumulator for (T, U) {
     fn remove(&mut self, white: Feature, black: Feature) {
         self.0.remove(white, black);
         self.1.remove(white, black);
+    }
+
+    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
+        self.0.replace(white, black);
+        self.1.replace(white, black);
     }
 
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {

--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -12,6 +12,7 @@ pub struct Hidden<const N: usize> {
 
 impl<const N: usize> Hidden<N> {
     #[doc(hidden)]
+    #[inline(always)]
     #[cfg(target_feature = "avx2")]
     pub unsafe fn avx2(&self, input: [&[i16; N]; 2]) -> i32 {
         const { assert!(N % 128 == 0) };
@@ -78,6 +79,7 @@ impl<const N: usize> Hidden<N> {
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     #[cfg(all(target_feature = "sse4.1", target_feature = "ssse3"))]
     pub unsafe fn sse(&self, input: [&[i16; N]; 2]) -> i32 {
         const { assert!(N % 64 == 0) };
@@ -137,6 +139,7 @@ impl<const N: usize> Hidden<N> {
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     pub fn scalar(&self, input: [&[i16; N]; 2]) -> i32 {
         let mut y = self.bias;
         for (w, i) in self.weight.iter().zip(input) {
@@ -151,6 +154,7 @@ impl<const N: usize> Hidden<N> {
 
 impl<const N: usize> Hidden<N> {
     /// Transforms the accumulator.
+    #[inline(always)]
     pub fn forward(&self, input: [&[i16; N]; 2]) -> i32 {
         #[cfg(target_feature = "avx2")]
         unsafe {

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -33,6 +33,12 @@ impl Accumulator for Material {
     }
 
     #[inline(always)]
+    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
+        Nnue::psqt().replace(white, &mut self.0[0]);
+        Nnue::psqt().replace(black, &mut self.0[1]);
+    }
+
+    #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
         (self.0[turn as usize][phase] - self.0[turn.mirror() as usize][phase]) / 32
     }

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -33,6 +33,12 @@ impl Accumulator for Positional {
     }
 
     #[inline(always)]
+    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
+        Nnue::ft().replace(white, &mut self.0[0]);
+        Nnue::ft().replace(black, &mut self.0[1]);
+    }
+
+    #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
         Nnue::hidden(phase).forward([&self.0[turn as usize], &self.0[turn.mirror() as usize]]) / 16
     }


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=-5 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 241 - 200 - 660  [0.519] 1101
...      dev playing White: 158 - 71 - 322  [0.579] 551
...      dev playing Black: 83 - 129 - 338  [0.458] 550
...      White vs Black: 287 - 154 - 660  [0.560] 1101
Elo difference: 12.9 +/- 13.0, LOS: 97.5 %, DrawRatio: 59.9 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Avalanche-2.1.0 -engine conf=Stash-35.0 -engine conf=Marvin-6.2 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                             6       6    9000    2847    2683    3470   4582.0   50.9%   38.6% 
   1 Marvin-6.2                     66       9    3000    1071     506    1423   1782.5   59.4%   47.4% 
   2 Stash-35.0                    -22      10    3000     916    1110     974   1403.0   46.8%   32.5% 
   3 Avalanche-2.1.0               -63      10    3000     696    1231    1073   1232.5   41.1%   35.8%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:02s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     52     59     67     64     56     52     55     43     63     53     55     58     58     52    853
   Score   7684   6668   7254   8084   7655   7711   6785   6851   5914   7307   6548   6717   6686   7197   6629 105690
Score(%)   90.4   83.3   84.3   90.8   90.1   96.4   82.7   85.6   83.3   92.5   93.5   90.8   89.1   91.1   90.8   89.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.4%, "Re-Capturing"
2. STS 11, 93.5%, "Activity of the King"
3. STS 10, 92.5%, "Simplification"
4. STS 14, 91.1%, "Queens and Rooks to the 7th rank"
5. STS 04, 90.8%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 07, 82.7%, "Offer of Simplification"
2. STS 09, 83.3%, "Advancement of a/b/c Pawns"
3. STS 02, 83.3%, "Open Files and Diagonals"
4. STS 03, 84.3%, "Knight Outposts"
5. STS 08, 85.6%, "Advancement of f/g/h Pawns"
```