### PR TITLE
Improve aspiration windows

### DIFF
--- a/lib/util/counter.rs
+++ b/lib/util/counter.rs
@@ -14,7 +14,7 @@ impl Counter {
         }
     }
 
-    /// Increments the counter and returns the counts remaining if any.
+    /// Increments the counter and returns the number of counts remaining if any.
     pub fn count(&self) -> Option<u64> {
         self.remaining
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_sub(1))
@@ -28,13 +28,13 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn counter_measures_time_remaining(#[strategy(1u64..)] c: u64) {
+    fn counter_keeps_track_of_counts(#[strategy(1u64..)] c: u64) {
         let counter = Counter::new(c);
         assert_eq!(counter.count(), Some(c - 1));
     }
 
     #[test]
-    fn counter_overflows_once_limit_is_reached() {
+    fn counter_stops_once_limit_is_reached() {
         let counter = Counter::new(0);
         assert_eq!(counter.count(), None);
     }


### PR DESCRIPTION


### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Avalanche-2.1.0 -engine conf=Stash-35.0 -engine conf=Marvin-6.2 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            14       6    8780    2900    2554    3326   4563.0   52.0%   37.9% 
   1 Marvin-6.2                     63       9    2926    1024     497    1405   1726.5   59.0%   48.0% 
   2 Stash-35.0                    -29      11    2926     898    1142     886   1341.0   45.8%   30.3% 
   3 Avalanche-2.1.0               -76      10    2928     632    1261    1035   1149.5   39.3%   35.3%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     55     62     72     65     56     48     48     46     59     48     60     59     57     47    851
   Score   7746   7138   7408   8331   7680   7718   6792   6422   5773   7262   6279   6956   6789   6908   6434 105636
Score(%)   91.1   89.2   86.1   93.6   90.4   96.5   82.8   80.3   81.3   91.9   89.7   94.0   90.5   87.4   88.1   88.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.5%, "Re-Capturing"
2. STS 12, 94.0%, "Center Control"
3. STS 04, 93.6%, "Square Vacancy"
4. STS 10, 91.9%, "Simplification"
5. STS 01, 91.1%, "Undermining"

:: Top 5 STS with low result ::
1. STS 08, 80.3%, "Advancement of f/g/h Pawns"
2. STS 09, 81.3%, "Advancement of a/b/c Pawns"
3. STS 07, 82.8%, "Offer of Simplification"
4. STS 03, 86.1%, "Knight Outposts"
5. STS 14, 87.4%, "Queens and Rooks to the 7th rank"

```






