### PR TITLE
Improve check extensions

### DIFF
--- a/lib/search/depth.rs
+++ b/lib/search/depth.rs
@@ -11,7 +11,7 @@ unsafe impl const Integer for DepthRepr {
     const MIN: Self::Repr = 0;
 
     #[cfg(not(test))]
-    const MAX: Self::Repr = 31;
+    const MAX: Self::Repr = 63;
 
     #[cfg(test)]
     const MAX: Self::Repr = 3;
@@ -21,7 +21,7 @@ unsafe impl const Integer for DepthRepr {
 pub type Depth = Saturating<DepthRepr>;
 
 impl Binary for Depth {
-    type Bits = Bits<u8, 5>;
+    type Bits = Bits<u8, 6>;
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -174,12 +174,17 @@ impl Engine {
 
         let depth = match tpos {
             #[cfg(not(test))]
+            // Extensions are not exact.
+            Some(_) if in_check => depth + 1,
+
+            #[cfg(not(test))]
             // Reductions are not exact.
-            None => depth - 1,
+            None if !in_check => depth - 1,
+
             _ => depth,
         };
 
-        let quiesce = ply >= depth && !in_check;
+        let quiesce = ply >= depth;
         let alpha = match quiesce {
             #[cfg(not(test))]
             // The stand pat heuristic is not exact.
@@ -377,7 +382,7 @@ mod tests {
 
         pos.moves()
             .flatten()
-            .filter(|m| ply < depth || pos.is_check() || !m.is_quiet())
+            .filter(|m| ply < depth || !m.is_quiet())
             .map(|m| {
                 let mut next = pos.clone();
                 next.play(m);

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -14,7 +14,7 @@ unsafe impl const Integer for PlyRepr {
     const MAX: Self::Repr = 127;
 
     #[cfg(test)]
-    const MAX: Self::Repr = 3;
+    const MAX: Self::Repr = 7;
 }
 
 /// The number of half-moves played.

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -100,7 +100,7 @@ impl Transposition {
 }
 
 impl Binary for Transposition {
-    type Bits = Bits<u64, 37>;
+    type Bits = Bits<u64, 38>;
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
@@ -123,7 +123,7 @@ impl Binary for Transposition {
     }
 }
 
-type Signature = Bits<u32, 27>;
+type Signature = Bits<u32, 26>;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=-5 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 2000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 453 - 409 - 1185  [0.511] 2047
...      dev playing White: 282 - 158 - 584  [0.561] 1024
...      dev playing Black: 171 - 251 - 601  [0.461] 1023
...      White vs Black: 533 - 329 - 1185  [0.550] 2047
Elo difference: 7.5 +/- 9.8, LOS: 93.3 %, DrawRatio: 57.9 %
SPRT: llr 3.01 (102.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Avalanche-2.1.0 -engine conf=Stash-35.0 -engine conf=Marvin-6.2 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            23       6    9000    3065    2463    3472   4801.0   53.3%   38.6% 
   1 Marvin-6.2                     55       9    3000    1027     560    1413   1733.5   57.8%   47.1% 
   2 Stash-35.0                    -42      10    3000     810    1175    1015   1317.5   43.9%   33.8% 
   3 Avalanche-2.1.0               -83      10    3000     626    1330    1044   1148.0   38.3%   34.8% 
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:03s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     58     58     69     70     51     56     54     46     57     48     58     62     57     47    853
   Score   7603   6949   7204   8201   7922   7640   7160   6811   5996   7074   6215   6828   6782   7031   6367 105783
Score(%)   89.4   86.9   83.8   92.1   93.2   95.5   87.3   85.1   84.5   89.5   88.8   92.3   90.4   89.0   87.2   89.0

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.5%, "Re-Capturing"
2. STS 05, 93.2%, "Bishop vs Knight"
3. STS 12, 92.3%, "Center Control"
4. STS 04, 92.1%, "Square Vacancy"
5. STS 13, 90.4%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 03, 83.8%, "Knight Outposts"
2. STS 09, 84.5%, "Advancement of a/b/c Pawns"
3. STS 08, 85.1%, "Advancement of f/g/h Pawns"
4. STS 02, 86.9%, "Open Files and Diagonals"
5. STS 15, 87.2%, "Avoid Pointless Exchange"
```