### PR TITLE
Implement fn TranspositionTable::prefetch

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -269,6 +269,7 @@ impl Engine {
             let mut next = pos.clone();
             next.play(m);
 
+            self.tt.prefetch(next.zobrist());
             if gain < 100 && !pos.is_check() && !next.is_check() {
                 if let Some(d) = self.lmp(&next, m, alpha.saturate(), depth, ply) {
                     if d <= ply || -self.nw(&next, -alpha, d, ply + 1, ctrl)? <= alpha {


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Avalanche-2.1.0 -engine conf=Stash-35.0 -engine conf=Marvin-6.2 -each tc=3+0.025`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            27       6    9000    3075    2387    3538   4844.0   53.8%   39.3% 
   1 Marvin-6.2                     49       9    3000     977     556    1467   1710.5   57.0%   48.9% 
   2 Stash-35.0                    -47      10    3000     808    1214     978   1297.0   43.2%   32.6% 
   3 Avalanche-2.1.0               -83      10    3000     602    1305    1093   1148.5   38.3%   36.4%
```

### STS1-STS15_LAN_v6.epd
> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 32, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:02s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     56     62     68     66     52     51     55     49     60     49     60     59     60     48    863
   Score   7776   6810   7402   8031   7844   7636   6686   6725   6107   7255   6270   6937   6703   7109   6528 105819
Score(%)   91.5   85.1   86.1   90.2   92.3   95.5   81.5   84.1   86.0   91.8   89.6   93.7   89.4   90.0   89.4   89.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.5%, "Re-Capturing"
2. STS 12, 93.7%, "Center Control"
3. STS 05, 92.3%, "Bishop vs Knight"
4. STS 10, 91.8%, "Simplification"
5. STS 01, 91.5%, "Undermining"

:: Top 5 STS with low result ::
1. STS 07, 81.5%, "Offer of Simplification"
2. STS 08, 84.1%, "Advancement of f/g/h Pawns"
3. STS 02, 85.1%, "Open Files and Diagonals"
4. STS 09, 86.0%, "Advancement of a/b/c Pawns"
5. STS 03, 86.1%, "Knight Outposts"
```