### PR TITLE
Trigger null move pruning also when score == beta

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -97,7 +97,7 @@ impl Engine {
         ply: Ply,
     ) -> Option<Depth> {
         let turn = pos.turn();
-        if guess > beta && pos.pieces(turn).len() > 1 {
+        if guess >= beta && pos.pieces(turn).len() > 1 {
             Some(depth - 2 - (depth - ply) / 4)
         } else {
             None


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -49       5    9000    1860    3129    4011   3865.5   43.0%   44.6% 
   1 Frozenight-6.0                 58       9    3000    1073     579    1348   1747.0   58.2%   44.9% 
   2 Marvin-6.2                     46       9    3000     988     592    1420   1698.0   56.6%   47.3% 
   3 Halogen-11.0                   44      10    3000    1068     689    1243   1689.5   56.3%   41.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     58     64     69     68     55     56     52     45     58     54     54     61     59     50    865
   Score   7485   7122   7579   7918   7876   7657   7152   6735   5942   7081   6485   6598   6813   7096   6578 106117
Score(%)   88.1   89.0   88.1   89.0   92.7   95.7   87.2   84.2   83.7   89.6   92.6   89.2   90.8   89.8   90.1   89.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.7%, "Re-Capturing"
2. STS 05, 92.7%, "Bishop vs Knight"
3. STS 11, 92.6%, "Activity of the King"
4. STS 13, 90.8%, "Pawn Play in the Center"
5. STS 15, 90.1%, "Avoid Pointless Exchange"

:: Top 5 STS with low result ::
1. STS 09, 83.7%, "Advancement of a/b/c Pawns"
2. STS 08, 84.2%, "Advancement of f/g/h Pawns"
3. STS 07, 87.2%, "Offer of Simplification"
4. STS 01, 88.1%, "Undermining"
5. STS 03, 88.1%, "Knight Outposts"
```