### PR TITLE
Tweak late move pruning margins

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -115,11 +115,11 @@ impl Engine {
         depth: Depth,
         ply: Ply,
     ) -> Option<Depth> {
-        let bounds = -(alpha - 60)..-(alpha - 501);
+        let bounds = -(alpha - 60)..-(alpha - 401);
         let r = match (alpha + next.clone().see(m.whither(), bounds)).get() {
             ..=60 => return None,
-            61..=180 => 1,
-            181..=500 => 2,
+            61..=200 => 1,
+            201..=400 => 2,
             _ => 3,
         };
 
@@ -270,7 +270,7 @@ impl Engine {
             next.play(m);
 
             self.tt.prefetch(next.zobrist());
-            if gain < 100 && !pos.is_check() && !next.is_check() {
+            if gain <= 0 && !pos.is_check() && !next.is_check() {
                 if let Some(d) = self.lmp(&next, m, alpha.saturate(), depth, ply) {
                     if d <= ply || -self.nw(&next, -alpha, d, ply + 1, ctrl)? <= alpha {
                         #[cfg(not(test))]


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -46       5    9000    1874    3053    4073   3910.5   43.5%   45.3% 
   1 Frozenight-6.0                 53       9    3000    1043     593    1364   1725.0   57.5%   45.5% 
   2 Marvin-6.2                     43       9    3000     952     585    1463   1683.5   56.1%   48.8% 
   3 Halogen-11.0                   42      10    3000    1058     696    1246   1681.0   56.0%   41.5% 
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     58     59     70     66     51     54     52     48     61     48     56     60     59     48    856
   Score   7696   7030   7231   8196   7803   7621   7118   6752   6114   7211   6154   6841   6650   7110   6487 106014
Score(%)   90.5   87.9   84.1   92.1   91.8   95.3   86.8   84.4   86.1   91.3   87.9   92.4   88.7   90.0   88.9   89.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.3%, "Re-Capturing"
2. STS 12, 92.4%, "Center Control"
3. STS 04, 92.1%, "Square Vacancy"
4. STS 05, 91.8%, "Bishop vs Knight"
5. STS 10, 91.3%, "Simplification"

:: Top 5 STS with low result ::
1. STS 03, 84.1%, "Knight Outposts"
2. STS 08, 84.4%, "Advancement of f/g/h Pawns"
3. STS 09, 86.1%, "Advancement of a/b/c Pawns"
4. STS 07, 86.8%, "Offer of Simplification"
5. STS 02, 87.9%, "Open Files and Diagonals"
```