### PR TITLE
Only ever refresh the NNUE accumulator for the moving side

### DIFF
--- a/lib/nnue/accumulator.rs
+++ b/lib/nnue/accumulator.rs
@@ -5,14 +5,17 @@ pub trait Accumulator: Default {
     /// The accumulator length.
     const LEN: usize;
 
-    /// Updates this accumulator by adding features.
-    fn add(&mut self, white: Feature, black: Feature);
+    /// Resets this accumulator.
+    fn refresh(&mut self, side: Color);
 
-    /// Updates this accumulator by removing features.
-    fn remove(&mut self, white: Feature, black: Feature);
+    /// Updates this accumulator by adding a feature.
+    fn add(&mut self, side: Color, feature: Feature);
 
-    /// Updates this accumulator by replacing features.
-    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]);
+    /// Updates this accumulator by removing a feature.
+    fn remove(&mut self, side: Color, feature: Feature);
+
+    /// Updates this accumulator by replacing a feature.
+    fn replace(&mut self, side: Color, remove: Feature, add: Feature);
 
     /// Evaluates this accumulator.
     fn evaluate(&self, turn: Color, phase: usize) -> i32;
@@ -21,21 +24,31 @@ pub trait Accumulator: Default {
 impl<T: Accumulator, U: Accumulator> Accumulator for (T, U) {
     const LEN: usize = T::LEN + U::LEN;
 
-    fn add(&mut self, white: Feature, black: Feature) {
-        self.0.add(white, black);
-        self.1.add(white, black);
+    #[inline(always)]
+    fn refresh(&mut self, side: Color) {
+        self.0.refresh(side);
+        self.1.refresh(side);
     }
 
-    fn remove(&mut self, white: Feature, black: Feature) {
-        self.0.remove(white, black);
-        self.1.remove(white, black);
+    #[inline(always)]
+    fn add(&mut self, side: Color, feature: Feature) {
+        self.0.add(side, feature);
+        self.1.add(side, feature);
     }
 
-    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
-        self.0.replace(white, black);
-        self.1.replace(white, black);
+    #[inline(always)]
+    fn remove(&mut self, side: Color, feature: Feature) {
+        self.0.remove(side, feature);
+        self.1.remove(side, feature);
     }
 
+    #[inline(always)]
+    fn replace(&mut self, side: Color, remove: Feature, add: Feature) {
+        self.0.replace(side, remove, add);
+        self.1.replace(side, remove, add);
+    }
+
+    #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
         self.0.evaluate(turn, phase) + self.1.evaluate(turn, phase)
     }

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -3,7 +3,7 @@ use crate::nnue::{Accumulator, Feature, Nnue};
 use crate::util::AlignTo64;
 
 /// An accumulator for the psqt transformer.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Material(
     #[cfg_attr(test, map(|vs: [[i8; Self::LEN]; 2]| AlignTo64(vs.map(|v| v.map(i32::from)))))]
@@ -21,21 +21,23 @@ impl Accumulator for Material {
     const LEN: usize = 8;
 
     #[inline(always)]
-    fn add(&mut self, white: Feature, black: Feature) {
-        Nnue::psqt().add(white, &mut self.0[0]);
-        Nnue::psqt().add(black, &mut self.0[1]);
+    fn refresh(&mut self, side: Color) {
+        self.0[side as usize] = Nnue::psqt().fresh();
     }
 
     #[inline(always)]
-    fn remove(&mut self, white: Feature, black: Feature) {
-        Nnue::psqt().remove(white, &mut self.0[0]);
-        Nnue::psqt().remove(black, &mut self.0[1]);
+    fn add(&mut self, side: Color, feature: Feature) {
+        Nnue::psqt().add(feature, &mut self.0[side as usize]);
     }
 
     #[inline(always)]
-    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
-        Nnue::psqt().replace(white, &mut self.0[0]);
-        Nnue::psqt().replace(black, &mut self.0[1]);
+    fn remove(&mut self, side: Color, feature: Feature) {
+        Nnue::psqt().remove(feature, &mut self.0[side as usize]);
+    }
+
+    #[inline(always)]
+    fn replace(&mut self, side: Color, remove: Feature, add: Feature) {
+        Nnue::psqt().replace(remove, add, &mut self.0[side as usize]);
     }
 
     #[inline(always)]
@@ -51,15 +53,23 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn material_evaluation_is_antisymmetric(e: Material, c: Color, #[strategy(..8usize)] p: usize) {
-        assert_eq!(e.evaluate(c, p), -e.evaluate(!c, p));
+    fn material_evaluation_is_antisymmetric(a: Material, c: Color, #[strategy(..8usize)] p: usize) {
+        assert_eq!(a.evaluate(c, p), -a.evaluate(!c, p));
     }
 
     #[proptest]
-    fn remove_reverses_add(e: Material, w: Feature, b: Feature) {
-        let mut f = e.clone();
-        f.add(w, b);
-        f.remove(w, b);
-        assert_eq!(e, f);
+    fn remove_reverses_add(a: Material, c: Color, f: Feature) {
+        let mut b = a;
+        b.add(c, f);
+        b.remove(c, f);
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn replace_reverses_itself(a: Material, c: Color, x: Feature, y: Feature) {
+        let mut b = a;
+        b.replace(c, x, y);
+        b.replace(c, y, x);
+        assert_eq!(a, b);
     }
 }

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -3,7 +3,7 @@ use crate::nnue::{Accumulator, Feature, Nnue};
 use crate::util::AlignTo64;
 
 /// An accumulator for the feature transformer.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Positional(
     #[cfg_attr(test, map(|vs: [[i8; Self::LEN]; 2]| AlignTo64(vs.map(|v| v.map(i16::from)))))]
@@ -21,21 +21,23 @@ impl Accumulator for Positional {
     const LEN: usize = 512;
 
     #[inline(always)]
-    fn add(&mut self, white: Feature, black: Feature) {
-        Nnue::ft().add(white, &mut self.0[0]);
-        Nnue::ft().add(black, &mut self.0[1]);
+    fn refresh(&mut self, side: Color) {
+        self.0[side as usize] = Nnue::ft().fresh();
     }
 
     #[inline(always)]
-    fn remove(&mut self, white: Feature, black: Feature) {
-        Nnue::ft().remove(white, &mut self.0[0]);
-        Nnue::ft().remove(black, &mut self.0[1]);
+    fn add(&mut self, side: Color, feature: Feature) {
+        Nnue::ft().add(feature, &mut self.0[side as usize]);
     }
 
     #[inline(always)]
-    fn replace(&mut self, white: [Feature; 2], black: [Feature; 2]) {
-        Nnue::ft().replace(white, &mut self.0[0]);
-        Nnue::ft().replace(black, &mut self.0[1]);
+    fn remove(&mut self, side: Color, feature: Feature) {
+        Nnue::ft().remove(feature, &mut self.0[side as usize]);
+    }
+
+    #[inline(always)]
+    fn replace(&mut self, side: Color, remove: Feature, add: Feature) {
+        Nnue::ft().replace(remove, add, &mut self.0[side as usize]);
     }
 
     #[inline(always)]
@@ -51,10 +53,18 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn remove_reverses_add(e: Positional, w: Feature, b: Feature) {
-        let mut f = e.clone();
-        f.add(w, b);
-        f.remove(w, b);
-        assert_eq!(e, f);
+    fn remove_reverses_add(a: Positional, c: Color, f: Feature) {
+        let mut b = a;
+        b.add(c, f);
+        b.remove(c, f);
+        assert_eq!(a, b);
+    }
+
+    #[proptest]
+    fn replace_reverses_itself(a: Positional, c: Color, x: Feature, y: Feature) {
+        let mut b = a;
+        b.replace(c, x, y);
+        b.replace(c, y, x);
+        assert_eq!(a, b);
     }
 }

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -71,7 +71,7 @@ where
 
     /// Updates the accumulator by replacing features.
     #[inline(always)]
-    pub fn replace(&self, [remove, add]: [Feature; 2], accumulator: &mut [T; N]) {
+    pub fn replace(&self, remove: Feature, add: Feature, accumulator: &mut [T; N]) {
         let a = self.weight.get(add.cast::<usize>()).assume().iter();
         let b = self.weight.get(remove.cast::<usize>()).assume().iter();
         for (y, (a, b)) in accumulator.iter_mut().zip(Iterator::zip(a, b)) {


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -35       5    9000    2019    2920    4061   4049.5   45.0%   45.1% 
   1 Frozenight-6.0                 49       9    3000    1054     635    1311   1709.5   57.0%   43.7% 
   2 Marvin-6.2                     33       9    3000     896     616    1488   1640.0   54.7%   49.6% 
   3 Halogen-11.0                   23       9    3000     970     768    1262   1601.0   53.4%   42.1%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     59     64     67     69     53     55     48     45     58     50     57     63     59     46    855
   Score   7520   7098   7609   7986   8032   7643   7037   6480   5960   7144   6266   6588   6910   6974   6368 105615
Score(%)   88.5   88.7   88.5   89.7   94.5   95.5   85.8   81.0   83.9   90.4   89.5   89.0   92.1   88.3   87.2   88.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.5%, "Re-Capturing"
2. STS 05, 94.5%, "Bishop vs Knight"
3. STS 13, 92.1%, "Pawn Play in the Center"
4. STS 10, 90.4%, "Simplification"
5. STS 04, 89.7%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 08, 81.0%, "Advancement of f/g/h Pawns"
2. STS 09, 83.9%, "Advancement of a/b/c Pawns"
3. STS 07, 85.8%, "Offer of Simplification"
4. STS 15, 87.2%, "Avoid Pointless Exchange"
5. STS 14, 88.3%, "Queens and Rooks to the 7th rank"
```