### PR TITLE
Implement uci command stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "criterion-macro",
  "ctor",
  "derive_more",
+ "futures",
  "proptest",
  "rand",
  "rand_pcg",
@@ -243,6 +244,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +430,18 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -531,6 +633,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ derive_more = { version = "1.0.0-beta.7", default-features = false, features = [
     "mul_assign",
     "not",
 ] }
+futures = { version = "0.3.30", default-features = false, features = [
+    "async-await",
+    "executor",
+    "std",
+] }
 rand = { version = "0.8.5", default-features = false, features = ["std", "min_const_gen"] }
 rand_pcg = { version = "0.3.1", default-features = false }
 rayon = { version = "1.10.0", default-features = false }

--- a/benches/search.rs
+++ b/benches/search.rs
@@ -3,8 +3,9 @@
 
 use criterion::{Criterion, SamplingMode, Throughput};
 use criterion_macro::criterion;
+use lib::nnue::Evaluator;
 use lib::search::{Depth, Engine, Limits, Options};
-use lib::{nnue::Evaluator, util::Integer};
+use lib::util::{Integer, Trigger};
 use std::time::{Duration, Instant};
 use std::{str::FromStr, thread::available_parallelism};
 
@@ -17,8 +18,9 @@ fn bench(reps: u64, options: Options, limits: Limits) -> Duration {
 
     for _ in 0..reps {
         let mut e = Engine::with_options(options);
+        let interrupter = Trigger::armed();
         let timer = Instant::now();
-        e.search(&POSITION, limits);
+        e.search(&POSITION, limits, &interrupter);
         time += timer.elapsed();
     }
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,8 +1,38 @@
+use futures::executor::{block_on, block_on_stream};
+use futures::{channel::mpsc, prelude::*};
 use lib::uci::Uci;
+use std::io::{prelude::*, stdin, stdout, LineWriter};
+use std::thread;
 
 fn main() {
-    let mut server = Uci::default();
-    if let Err(e) = server.run() {
-        panic!("{}", e);
-    }
+    thread::scope(|s| {
+        let (mut tx, input) = mpsc::channel(32);
+        let (output, rx) = mpsc::channel(32);
+
+        s.spawn(move || {
+            for item in stdin().lock().lines() {
+                match item {
+                    Err(error) => return eprint!("{error}"),
+                    Ok(line) => {
+                        if let Err(error) = block_on(tx.send(line)) {
+                            if error.is_disconnected() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        s.spawn(move || {
+            let mut stdout = LineWriter::new(stdout().lock());
+            for line in block_on_stream(rx) {
+                if let Err(error) = writeln!(stdout, "{line}") {
+                    return eprint!("{error}");
+                }
+            }
+        });
+
+        block_on(Uci::new(input, output).run()).ok();
+    });
 }

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -44,6 +44,7 @@ unsafe fn init() {
 }
 
 impl Nnue {
+    #[inline(always)]
     fn load<T: Read>(&mut self, mut reader: T) -> io::Result<()> {
         reader.read_i16_into::<LittleEndian>(&mut *self.ft.bias)?;
         reader.read_i16_into::<LittleEndian>(unsafe {

--- a/lib/search.rs
+++ b/lib/search.rs
@@ -1,3 +1,4 @@
+mod control;
 mod depth;
 mod driver;
 mod engine;
@@ -9,6 +10,7 @@ mod pv;
 mod score;
 mod transposition;
 
+pub use control::*;
 pub use depth::*;
 pub use driver::*;
 pub use engine::*;

--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -1,0 +1,37 @@
+use crate::util::{Counter, Timer};
+use derive_more::{Display, Error};
+
+/// Indicates the search was interrupted .
+#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Error)]
+#[display("the search was interrupted")]
+pub struct Interrupted;
+
+/// The search control.
+#[derive(Debug, Default)]
+pub enum Control {
+    #[default]
+    Unlimited,
+    Limited(Counter, Timer),
+}
+
+impl Control {
+    /// A reference to the timer.
+    #[inline(always)]
+    pub fn timer(&self) -> &Timer {
+        match self {
+            Control::Unlimited => &const { Timer::infinite() },
+            Control::Limited(_, timer) => timer,
+        }
+    }
+
+    /// Whether the search should be interrupted.
+    #[inline(always)]
+    pub fn interrupted(&self) -> Result<(), Interrupted> {
+        if let Control::Limited(nodes, timer) = self {
+            nodes.count().ok_or(Interrupted)?;
+            timer.remaining().ok_or(Interrupted)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/search/driver.rs
+++ b/lib/search/driver.rs
@@ -1,13 +1,8 @@
-use crate::search::{Pv, ThreadCount};
+use crate::search::{Interrupted, Pv, ThreadCount};
 use crate::util::{Binary, Bits, Integer};
-use derive_more::{Deref, Display, Error, From};
+use derive_more::{Deref, From};
 use rayon::{prelude::*, ThreadPool, ThreadPoolBuilder};
 use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Indicates the search was interrupted upon reaching the configured [`crate::search::Limits`].
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Error)]
-#[display("the search was interrupted")]
-pub struct Interrupted;
 
 /// Whether the search should be [`Interrupted`] or exited early.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -4,12 +4,32 @@ use crate::search::{Engine, HashSize, Limits, Options, Score, ThreadCount};
 use crate::util::{Assume, Integer, Trigger};
 use arrayvec::ArrayString;
 use derive_more::{Deref, Display};
-use std::fmt::Debug;
-use std::io::{self, stdin, stdout, BufRead, StdinLock, StdoutLock, Write};
+use futures::{channel::oneshot, future::FusedFuture, prelude::*, select_biased as select};
 use std::time::{Duration, Instant};
+use std::{fmt::Debug, mem::transmute, thread};
 
 #[cfg(test)]
 use proptest::prelude::*;
+
+/// Runs the provided closure on a thread where blocking is acceptable.
+///
+/// # Safety
+///
+/// Must be awaited on through completion strictly before any
+/// of the variables `f` may capture is dropped.
+#[must_use]
+unsafe fn unblock<'a, F, R>(f: F) -> impl FusedFuture<Output = R> + 'a
+where
+    F: FnOnce() -> R + Send + 'a,
+    R: Send + 'a,
+{
+    let (tx, rx) = oneshot::channel();
+    thread::spawn(transmute::<
+        Box<dyn FnOnce() + Send + 'a>,
+        Box<dyn FnOnce() + Send + 'static>,
+    >(Box::new(move || tx.send(f()).assume()) as _));
+    rx.map(Assume::assume)
+}
 
 #[derive(Debug, Display, Default, Clone, Eq, PartialEq, Hash, Deref)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -31,12 +51,12 @@ impl PartialEq<&str> for UciMove {
     }
 }
 
-/// A basic *not fully compliant* UCI server.
-#[derive(Debug)]
+/// A basic UCI server.
+#[derive(Debug, Default)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[cfg_attr(test, arbitrary(args = I,
     bound(I: 'static + Debug + Default + Clone, O: 'static + Debug + Default + Clone)))]
-pub struct Uci<I: BufRead, O: Write> {
+pub struct Uci<I, O> {
     #[cfg_attr(test, strategy(Just(args.clone())))]
     input: I,
     #[cfg_attr(test, strategy(Just(O::default())))]
@@ -47,13 +67,7 @@ pub struct Uci<I: BufRead, O: Write> {
     moves: Vec<UciMove>,
 }
 
-impl Default for Uci<StdinLock<'_>, StdoutLock<'_>> {
-    fn default() -> Self {
-        Self::new(stdin().lock(), stdout().lock())
-    }
-}
-
-impl<I: BufRead, O: Write> Uci<I, O> {
+impl<I, O> Uci<I, O> {
     /// Constructs a new uci server instance.
     pub fn new(input: I, output: O) -> Self {
         Self {
@@ -65,12 +79,13 @@ impl<I: BufRead, O: Write> Uci<I, O> {
             moves: Vec::with_capacity(128),
         }
     }
+}
 
+impl<I: Stream<Item = String> + Unpin, O: Sink<String> + Unpin> Uci<I, O> {
     /// Runs the UCI server.
-    pub fn run(&mut self) -> io::Result<()> {
-        while let Some(line) = (&mut self.input).lines().next().transpose()? {
-            self.output.flush()?;
-            if !self.process(&line)? {
+    pub async fn run(&mut self) -> Result<(), O::Error> {
+        while let Some(line) = self.input.next().await {
+            if !self.process(&line).await? {
                 break;
             };
         }
@@ -79,61 +94,79 @@ impl<I: BufRead, O: Write> Uci<I, O> {
     }
 
     fn play(&mut self, uci: &str) {
-        if !(0..=5).contains(&uci.len()) || !uci.is_ascii() {
-            return eprintln!("invalid move `{uci}`");
-        };
-
         let mut moves = self.position.moves().flatten();
         let Some(m) = moves.find(|&m| UciMove::from(m) == uci) else {
-            return eprintln!("illegal move `{uci}` in position `{}`", self.position);
+            return if !(0..=5).contains(&uci.len()) || !uci.is_ascii() {
+                eprintln!("invalid move `{uci}`")
+            } else {
+                eprintln!("illegal move `{uci}` in position `{}`", self.position)
+            };
         };
 
         self.position.play(m);
         self.moves.push(UciMove::from(m));
     }
 
-    fn go(&mut self, limits: Limits) -> io::Result<()> {
+    async fn go(&mut self, limits: Limits) -> Result<(), O::Error> {
         let interrupter = Trigger::armed();
-        let pv = self.engine.search(&self.position, limits, &interrupter);
+
+        let mut search =
+            unsafe { unblock(|| self.engine.search(&self.position, limits, &interrupter)) };
+
+        let stop = async {
+            loop {
+                match self.input.next().await.as_deref().map(str::trim) {
+                    None => break false,
+                    Some("stop") => break interrupter.disarm(),
+                    Some(cmd) => eprintln!("ignored unsupported command `{cmd}` during search"),
+                };
+            }
+        };
+
+        let pv = select! {
+            pv = search => pv,
+            _ = stop.fuse() => search.await
+        };
+
         let best = pv.best().expect("the engine failed to find a move");
+        let info = match pv.score().mate() {
+            Some(p) if p > 0 => format!("info score mate {} pv {best}", (p + 1).get() / 2),
+            Some(p) => format!("info score mate {} pv {best}", (p - 1).get() / 2),
+            None => format!("info score cp {} pv {best}", pv.score().get()),
+        };
 
-        match pv.score().mate() {
-            Some(p) if p > 0 => write!(self.output, "info score mate {}", (p + 1).get() / 2),
-            Some(p) => write!(self.output, "info score mate {}", (p - 1).get() / 2),
-            None => write!(self.output, "info score cp {}", pv.score().get()),
-        }?;
-
-        writeln!(self.output, " pv {best}")?;
-        writeln!(self.output, "bestmove {best}")?;
+        self.output.send(info).await?;
+        self.output.send(format!("bestmove {best}")).await?;
 
         Ok(())
     }
 
-    fn bench(&mut self, limits: Limits) -> io::Result<()> {
+    async fn bench(&mut self, limits: Limits) -> Result<(), O::Error> {
         let interrupter = Trigger::armed();
         let timer = Instant::now();
         self.engine.search(&self.position, limits, &interrupter);
-        let elapsed = timer.elapsed();
-        write!(self.output, "info time {}", elapsed.as_millis())?;
+        let millis = timer.elapsed().as_millis();
 
-        match limits {
-            Limits::Depth(d) => writeln!(self.output, " depth {}", d.get())?,
-            Limits::Nodes(nodes) => {
-                let nps = nodes as f64 / elapsed.as_secs_f64();
-                writeln!(self.output, " nodes {nodes} nps {nps:.0}")?
-            }
-            _ => writeln!(self.output)?,
-        }
+        let info = match limits {
+            Limits::Depth(d) => format!("info time {millis} depth {}", d.get()),
+            Limits::Nodes(nodes) => format!(
+                "info time {millis} nodes {nodes} nps {}",
+                nodes as u128 * 1000 / millis
+            ),
+            _ => return Ok(()),
+        };
 
-        Ok(())
+        self.output.send(info).await
     }
 
     /// Processes one [`UciMessage`].
-    fn process(&mut self, line: &str) -> io::Result<bool> {
+    async fn process(&mut self, line: &str) -> Result<bool, O::Error> {
         let tokens: Vec<_> = line.split_whitespace().collect();
 
         match &tokens[..] {
             [] => Ok(true),
+            ["stop"] => Ok(true),
+            ["quit"] => Ok(false),
 
             ["position", "startpos", "moves", m, n] => {
                 self.position = Evaluator::default();
@@ -185,7 +218,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
                     (Ok(t), Ok(i)) => {
                         let t = Duration::from_millis(t);
                         let i = Duration::from_millis(i);
-                        self.go(Limits::Clock(t, i))?
+                        self.go(Limits::Clock(t, i)).await?;
                     }
                 }
 
@@ -194,7 +227,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
 
             ["go", "depth", depth] => {
                 match depth.parse::<u8>() {
-                    Ok(d) => self.go(Limits::Depth(d.saturate()))?,
+                    Ok(d) => self.go(Limits::Depth(d.saturate())).await?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -203,7 +236,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
 
             ["go", "nodes", nodes] => {
                 match nodes.parse::<u64>() {
-                    Ok(n) => self.go(n.into())?,
+                    Ok(n) => self.go(n.into()).await?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -212,7 +245,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
 
             ["go", "movetime", time] => {
                 match time.parse() {
-                    Ok(ms) => self.go(Duration::from_millis(ms).into())?,
+                    Ok(ms) => self.go(Duration::from_millis(ms).into()).await?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -220,13 +253,13 @@ impl<I: BufRead, O: Write> Uci<I, O> {
             }
 
             ["go"] | ["go", "infinite"] => {
-                self.go(Limits::None)?;
+                self.go(Limits::None).await?;
                 Ok(true)
             }
 
             ["bench", "depth", depth] => {
                 match depth.parse::<u8>() {
-                    Ok(d) => self.bench(Limits::Depth(d.saturate()))?,
+                    Ok(d) => self.bench(Limits::Depth(d.saturate())).await?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -235,7 +268,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
 
             ["bench", "nodes", nodes] => {
                 match nodes.parse::<u64>() {
-                    Ok(n) => self.bench(n.into())?,
+                    Ok(n) => self.bench(n.into()).await?,
                     Err(e) => eprintln!("{e}"),
                 }
 
@@ -245,39 +278,37 @@ impl<I: BufRead, O: Write> Uci<I, O> {
             ["eval"] => {
                 let pos = &self.position;
                 let turn = self.position.turn();
-                let material: Score = pos.material().evaluate().perspective(turn).saturate();
+                let mat: Score = pos.material().evaluate().perspective(turn).saturate();
                 let positional: Score = pos.positional().evaluate().perspective(turn).saturate();
-                let evaluation: Score = pos.evaluate().perspective(turn).saturate();
-
-                writeln!(
-                    self.output,
-                    "info material {material} positional {positional} value {evaluation}"
-                )?;
-
+                let value: Score = pos.evaluate().perspective(turn).saturate();
+                let info = format!("info material {mat} positional {positional} value {value}");
+                self.output.send(info).await?;
                 Ok(true)
             }
 
             ["uci"] => {
-                writeln!(self.output, "id name {}", env!("CARGO_PKG_NAME"))?;
-                writeln!(self.output, "id author {}", env!("CARGO_PKG_AUTHORS"))?;
+                let name = format!("id name {}", env!("CARGO_PKG_NAME"));
+                let author = format!("id author {}", env!("CARGO_PKG_AUTHORS"));
 
-                writeln!(
-                    self.output,
+                let hash = format!(
                     "option name Hash type spin default {} min {} max {}",
                     HashSize::default(),
                     HashSize::lower(),
                     HashSize::upper()
-                )?;
+                );
 
-                writeln!(
-                    self.output,
+                let threads = format!(
                     "option name Threads type spin default {} min {} max {}",
                     ThreadCount::default(),
                     ThreadCount::lower(),
                     ThreadCount::upper()
-                )?;
+                );
 
-                writeln!(self.output, "uciok")?;
+                self.output.send(name).await?;
+                self.output.send(author).await?;
+                self.output.send(hash).await?;
+                self.output.send(threads).await?;
+                self.output.send("uciok".to_string()).await?;
 
                 Ok(true)
             }
@@ -290,7 +321,7 @@ impl<I: BufRead, O: Write> Uci<I, O> {
             }
 
             ["isready"] => {
-                writeln!(self.output, "readyok")?;
+                self.output.send("readyok".to_string()).await?;
                 Ok(true)
             }
 
@@ -324,8 +355,6 @@ impl<I: BufRead, O: Write> Uci<I, O> {
                 Ok(true)
             }
 
-            ["quit"] => Ok(false),
-
             cmd => {
                 eprintln!("ignored unsupported command `{}`", cmd.join(" "));
                 Ok(true)
@@ -338,17 +367,30 @@ impl<I: BufRead, O: Write> Uci<I, O> {
 mod tests {
     use super::*;
     use crate::search::Depth;
+    use futures::executor::block_on;
     use proptest::sample::Selector;
-    use std::{io::Cursor, str};
+    use std::task::{Context, Poll};
+    use std::{collections::VecDeque, pin::Pin};
     use test_strategy::proptest;
 
-    type MockUci = Uci<Cursor<String>, Vec<u8>>;
+    #[derive(Debug, Default, Clone, Eq, PartialEq)]
+    struct StaticStream(VecDeque<String>);
 
-    impl Default for MockUci {
-        fn default() -> Self {
-            Self::new(Cursor::new(String::new()), Vec::new())
+    impl StaticStream {
+        fn new(items: impl IntoIterator<Item = impl ToString>) -> Self {
+            Self(items.into_iter().map(|s| s.to_string()).collect())
         }
     }
+
+    impl Stream for StaticStream {
+        type Item = String;
+
+        fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(self.0.pop_front())
+        }
+    }
+
+    type MockUci = Uci<StaticStream, Vec<String>>;
 
     #[proptest]
     fn play_updates_position(
@@ -418,9 +460,9 @@ mod tests {
 
     #[proptest]
     fn handles_position_with_startpos(
-        #[any(Cursor::new("position startpos".to_string()))] mut uci: MockUci,
+        #[any(StaticStream::new(["position startpos"]))] mut uci: MockUci,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.position, Evaluator::default());
         assert!(uci.moves.is_empty());
         assert!(uci.output.is_empty());
@@ -428,10 +470,10 @@ mod tests {
 
     #[proptest]
     fn handles_position_with_fen(
-        #[any(Cursor::new(format!("position fen {}", #pos)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("position fen {}", #pos)]))] mut uci: MockUci,
         pos: Evaluator,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.position.to_string(), pos.to_string());
         assert!(uci.moves.is_empty());
         assert!(uci.output.is_empty());
@@ -439,12 +481,12 @@ mod tests {
 
     #[proptest]
     fn ignores_invalid_fen(
-        #[any(Cursor::new(format!("position fen {}", #_s)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("position fen {}", #_s)]))] mut uci: MockUci,
         #[filter(#_s.parse::<Evaluator>().is_err())] _s: String,
     ) {
         let pos = uci.position.clone();
         let moves = uci.moves.clone();
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.position, pos);
         assert_eq!(uci.moves, moves);
         assert!(uci.output.is_empty());
@@ -467,8 +509,8 @@ mod tests {
             pos.play(m);
         }
 
-        uci.input = Cursor::new(input);
-        assert_eq!(uci.run().ok(), Some(()));
+        uci.input = StaticStream::new([input]);
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.position, pos);
         assert_eq!(uci.moves, moves);
         assert!(uci.output.is_empty());
@@ -477,71 +519,106 @@ mod tests {
     #[proptest]
     fn handles_go_time_left(
         #[filter(#uci.position.outcome().is_none())]
-        #[any(Cursor::new(format!("go wtime {} btime {} winc {} binc {}", #_wt, #_bt, #_wi, #_bi)))]
+        #[any(StaticStream::new([format!("go wtime {} btime {} winc {} binc {}", #_wt, #_bt, #_wi, #_bi)]))]
         mut uci: MockUci,
         #[strategy(..10u8)] _wt: u8,
         #[strategy(..10u8)] _wi: u8,
         #[strategy(..10u8)] _bt: u8,
         #[strategy(..10u8)] _bi: u8,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("bestmove"));
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
     }
 
     #[proptest]
     fn handles_go_depth(
         #[filter(#uci.position.outcome().is_none())]
-        #[any(Cursor::new(format!("go depth {}", #_d.get())))]
+        #[any(StaticStream::new([format!("go depth {}", #_d.get())]))]
         mut uci: MockUci,
         _d: Depth,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("bestmove"));
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
     }
 
     #[proptest]
     fn handles_go_nodes(
         #[filter(#uci.position.outcome().is_none())]
-        #[any(Cursor::new(format!("go nodes {}", #_n)))]
+        #[any(StaticStream::new([format!("go nodes {}", #_n)]))]
         mut uci: MockUci,
         #[strategy(..1000u64)] _n: u64,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("bestmove"));
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
     }
 
     #[proptest]
     fn handles_go_time(
         #[filter(#uci.position.outcome().is_none())]
-        #[any(Cursor::new(format!("go movetime {}", #_ms)))]
+        #[any(StaticStream::new([format!("go movetime {}", #_ms)]))]
         mut uci: MockUci,
         #[strategy(..10u8)] _ms: u8,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("bestmove"));
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
     }
 
     #[proptest]
-    fn handles_eval(#[any(Cursor::new("eval".to_string()))] mut uci: MockUci) {
+    fn handles_go(
+        #[by_ref]
+        #[filter(#uci.position.outcome().is_none())]
+        #[any(StaticStream::new(["go"]))]
+        mut uci: MockUci,
+    ) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
+    }
+
+    #[proptest]
+    fn handles_stop_during_search(
+        #[by_ref]
+        #[filter(#uci.position.outcome().is_none())]
+        #[any(StaticStream::new(["go", "stop"]))]
+        mut uci: MockUci,
+    ) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().contains("bestmove"));
+    }
+
+    #[proptest]
+    fn handles_stop(#[any(StaticStream::new(["stop"]))] mut uci: MockUci) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.is_empty());
+    }
+
+    #[proptest]
+    fn handles_quit(#[any(StaticStream::new(["quit"]))] mut uci: MockUci) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.is_empty());
+    }
+
+    #[proptest]
+    fn handles_eval(#[any(StaticStream::new(["eval"]))] mut uci: MockUci) {
         let pos = uci.position.clone();
         let value = match pos.turn() {
             Color::White => pos.evaluate(),
             Color::Black => -pos.evaluate(),
         };
 
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains(&format!("value {:+}", value.get())));
+        let value = format!("value {:+}", value.get());
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().ends_with(&value));
     }
 
     #[proptest]
-    fn handles_uci(#[any(Cursor::new("uci".to_string()))] mut uci: MockUci) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("uciok"));
+    fn handles_uci(#[any(StaticStream::new(["uci"]))] mut uci: MockUci) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert!(uci.output.concat().ends_with("uciok"));
     }
 
     #[proptest]
-    fn handles_new_game(#[any(Cursor::new("ucinewgame".to_string()))] mut uci: MockUci) {
-        assert_eq!(uci.run().ok(), Some(()));
+    fn handles_new_game(#[any(StaticStream::new(["ucinewgame"]))] mut uci: MockUci) {
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.position, Evaluator::default());
         assert!(uci.moves.is_empty());
         assert!(uci.output.is_empty());
@@ -549,64 +626,60 @@ mod tests {
 
     #[proptest]
     fn handles_option_hash(
-        #[any(Cursor::new(format!("setoption name Hash value {}", #h)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("setoption name Hash value {}", #h)]))] mut uci: MockUci,
         h: HashSize,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.options.hash, h >> 20 << 20);
         assert!(uci.output.is_empty());
     }
 
     #[proptest]
     fn ignores_invalid_hash_size(
-        #[any(Cursor::new(format!("setoption name Hash value {}", #_s)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("setoption name Hash value {}", #_s)]))] mut uci: MockUci,
         #[filter(#_s.trim().parse::<HashSize>().is_err())] _s: String,
     ) {
         let o = uci.options;
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.options, o);
         assert!(uci.output.is_empty());
     }
 
     #[proptest]
     fn handles_option_threads(
-        #[any(Cursor::new(format!("setoption name Threads value {}", #t)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("setoption name Threads value {}", #t)]))]
+        mut uci: MockUci,
         t: ThreadCount,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.options.threads, t);
         assert!(uci.output.is_empty());
     }
 
     #[proptest]
     fn ignores_invalid_thread_count(
-        #[any(Cursor::new(format!("setoption name Threads value {}", #_s)))] mut uci: MockUci,
+        #[any(StaticStream::new([format!("setoption name Threads value {}", #_s)]))]
+        mut uci: MockUci,
         #[filter(#_s.trim().parse::<ThreadCount>().is_err())] _s: String,
     ) {
         let o = uci.options;
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert_eq!(uci.options, o);
         assert!(uci.output.is_empty());
     }
 
     #[proptest]
-    fn handles_ready(#[any(Cursor::new("isready".to_string()))] mut uci: MockUci) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(str::from_utf8(&uci.output)?.contains("readyok"));
-    }
-
-    #[proptest]
-    fn handles_quit(#[any(Cursor::new("quit".to_string()))] mut uci: MockUci) {
-        assert_eq!(uci.run().ok(), Some(()));
-        assert!(uci.output.is_empty());
+    fn handles_ready(#[any(StaticStream::new(["isready"]))] mut uci: MockUci) {
+        assert_eq!(block_on(uci.run()), Ok(()));
+        assert_eq!(uci.output.concat(), "readyok");
     }
 
     #[proptest]
     fn ignores_unsupported_messages(
-        #[any(Cursor::new(#_s))] mut uci: MockUci,
+        #[any(StaticStream::new([#_s]))] mut uci: MockUci,
         #[strategy("[^pgbeuisq].*")] _s: String,
     ) {
-        assert_eq!(uci.run().ok(), Some(()));
+        assert_eq!(block_on(uci.run()), Ok(()));
         assert!(uci.output.is_empty());
     }
 }

--- a/lib/util.rs
+++ b/lib/util.rs
@@ -6,6 +6,7 @@ mod counter;
 mod integer;
 mod saturating;
 mod timer;
+mod trigger;
 
 pub use align::*;
 pub use assume::*;
@@ -15,3 +16,4 @@ pub use counter::*;
 pub use integer::*;
 pub use saturating::*;
 pub use timer::*;
+pub use trigger::*;

--- a/lib/util/align.rs
+++ b/lib/util/align.rs
@@ -1,10 +1,6 @@
 use derive_more::{Deref, DerefMut, IntoIterator};
 
-#[cfg(test)]
-use proptest::prelude::*;
-
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deref, DerefMut, IntoIterator)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[cfg_attr(test, arbitrary(bound(T: 'static + Arbitrary)))]
 #[repr(align(64))]
 pub struct AlignTo64<T>(#[cfg_attr(test, into_iterator(owned, ref, ref_mut))] pub T);

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -28,7 +28,7 @@ use std::ops::RangeInclusive;
     BitXorAssign,
 )]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-#[cfg_attr(test, arbitrary(bound(T: 'static + Debug + Unsigned, Self: Debug, RangeInclusive<T>: Strategy<Value = T>)))]
+#[cfg_attr(test, arbitrary(bound(T, T: Unsigned, Self: Debug, RangeInclusive<T>: Strategy<Value = T>)))]
 #[debug("Bits({_0:b})")]
 #[display("{_0:b}")]
 #[repr(transparent)]

--- a/lib/util/counter.rs
+++ b/lib/util/counter.rs
@@ -8,6 +8,7 @@ pub struct Counter {
 
 impl Counter {
     /// Constructs a counter with the given limit.
+    #[inline(always)]
     pub fn new(limit: u64) -> Self {
         Counter {
             remaining: AtomicU64::new(limit),
@@ -15,6 +16,7 @@ impl Counter {
     }
 
     /// Increments the counter and returns the number of counts remaining if any.
+    #[inline(always)]
     pub fn count(&self) -> Option<u64> {
         self.remaining
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_sub(1))
@@ -28,7 +30,7 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn counter_keeps_track_of_counts(#[strategy(1u64..)] c: u64) {
+    fn counter_keeps_track_of_counts_remaining(#[strategy(1u64..)] c: u64) {
         let counter = Counter::new(c);
         assert_eq!(counter.count(), Some(c - 1));
     }

--- a/lib/util/timer.rs
+++ b/lib/util/timer.rs
@@ -1,13 +1,20 @@
 use std::time::{Duration, Instant};
 
 /// Tracks time towards a deadline.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Timer {
     deadline: Option<Instant>,
 }
 
 impl Timer {
     /// Constructs a timer that elapses after the given duration.
+    #[inline(always)]
+    pub const fn infinite() -> Self {
+        Timer { deadline: None }
+    }
+
+    /// Constructs a timer that elapses after the given duration.
+    #[inline(always)]
     pub fn new(duration: Duration) -> Self {
         Timer {
             deadline: Instant::now().checked_add(duration),
@@ -15,6 +22,7 @@ impl Timer {
     }
 
     /// Returns the time remaining if any.
+    #[inline(always)]
     pub fn remaining(&self) -> Option<Duration> {
         match self.deadline {
             Some(deadline) => deadline.checked_duration_since(Instant::now()),
@@ -35,15 +43,17 @@ mod tests {
     }
 
     #[test]
-    fn timer_does_not_elapse_before_duration_expires() {
-        let timer = Timer::new(Duration::MAX);
-        assert_eq!(timer.remaining(), Some(Duration::MAX));
-    }
-
-    #[test]
     fn timer_elapses_once_duration_expires() {
         let timer = Timer::new(Duration::ZERO);
         sleep(Duration::from_millis(1));
         assert_eq!(timer.remaining(), None);
+    }
+
+    #[test]
+    fn timer_never_decreases_if_infinite() {
+        let timer = Timer::infinite();
+        let remaining = timer.remaining();
+        sleep(Duration::from_millis(1));
+        assert_eq!(remaining, timer.remaining());
     }
 }

--- a/lib/util/trigger.rs
+++ b/lib/util/trigger.rs
@@ -1,0 +1,47 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A one-shot trigger.
+#[derive(Debug)]
+pub struct Trigger(AtomicBool);
+
+impl Trigger {
+    /// An armed trigger.
+    #[inline(always)]
+    pub const fn armed() -> Self {
+        Trigger(AtomicBool::new(true))
+    }
+
+    /// A disarmed trigger.
+    #[inline(always)]
+    pub const fn disarmed() -> Self {
+        Trigger(AtomicBool::new(false))
+    }
+
+    /// Disarm the trigger.
+    ///
+    /// Returns `true` if the trigger was disarmed for the first time.
+    #[inline(always)]
+    pub fn disarm(&self) -> bool {
+        self.0.fetch_and(false, Ordering::Relaxed)
+    }
+
+    /// Whether the trigger is armed.
+    #[inline(always)]
+    pub fn is_armed(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trigger_can_only_be_disarmed_once() {
+        let trigger = Trigger::armed();
+        assert!(trigger.is_armed());
+        assert!(trigger.disarm());
+        assert!(!trigger.is_armed());
+        assert!(!trigger.disarm());
+    }
+}


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -40       5    9000    1968    2994    4038   3987.0   44.3%   44.9% 
   1 Frozenight-6.0                 53       9    3000    1053     601    1346   1726.0   57.5%   44.9% 
   2 Halogen-11.0                   35      10    3000    1033     736    1231   1648.5   54.9%   41.0% 
   3 Marvin-6.2                     32       9    3000     908     631    1461   1638.5   54.6%   48.7%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:16s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     60     57     55     72     65     50     49     40     46     61     49     53     58     55     48    818
   Score   7299   6955   6987   8230   7782   7578   6717   6003   6033   7314   6329   6592   6726   6996   6380 103921
Score(%)   85.9   86.9   81.2   92.5   91.6   94.7   81.9   75.0   85.0   92.6   90.4   89.1   89.7   88.6   87.4   87.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.7%, "Re-Capturing"
2. STS 10, 92.6%, "Simplification"
3. STS 04, 92.5%, "Square Vacancy"
4. STS 05, 91.6%, "Bishop vs Knight"
5. STS 11, 90.4%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 08, 75.0%, "Advancement of f/g/h Pawns"
2. STS 03, 81.2%, "Knight Outposts"
3. STS 07, 81.9%, "Offer of Simplification"
4. STS 09, 85.0%, "Advancement of a/b/c Pawns"
5. STS 01, 85.9%, "Undermining"
```