### PR TITLE
Reduce Value range to +-4000

### DIFF
--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -103,7 +103,7 @@ mod tests {
             for weights in features.array_chunks_mut::<768>() {
                 let (small, _, _) = weights.select_nth_unstable(32);
                 assert!(small.iter().fold(bias, |s, &v| s + v).abs() <= i16::MAX as i32);
-                let (_, _, large) = weights.select_nth_unstable(Positional::LEN - 33);
+                let (_, _, large) = weights.select_nth_unstable(735);
                 assert!(large.iter().fold(bias, |s, &v| s + v).abs() <= i16::MAX as i32);
             }
         });

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -44,7 +44,7 @@ impl Accumulator for Material {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        (self.0[turn as usize][phase] - self.0[turn.flip() as usize][phase]) / 32
+        (self.0[turn as usize][phase] - self.0[turn.flip() as usize][phase]) / 80
     }
 }
 

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -44,7 +44,7 @@ impl Accumulator for Positional {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        Nnue::hidden(phase).forward([&self.0[turn as usize], &self.0[turn.flip() as usize]]) / 16
+        Nnue::hidden(phase).forward([&self.0[turn as usize], &self.0[turn.flip() as usize]]) / 40
     }
 }
 

--- a/lib/nnue/value.rs
+++ b/lib/nnue/value.rs
@@ -9,7 +9,7 @@ pub struct ValueRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as
 unsafe impl Integer for ValueRepr {
     type Repr = i16;
     const MIN: Self::Repr = -Self::MAX;
-    const MAX: Self::Repr = 8000;
+    const MAX: Self::Repr = 4000;
 }
 
 /// A position's static evaluation.

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -103,11 +103,11 @@ impl Engine {
         depth: Depth,
         ply: Ply,
     ) -> Option<Depth> {
-        let bounds = -(alpha - 60)..-(alpha - 401);
+        let bounds = -(alpha - 24)..-(alpha - 161);
         let r = match (alpha + next.clone().see(m.whither(), bounds)).get() {
-            ..=60 => return None,
-            61..=200 => 1,
-            201..=400 => 2,
+            ..=24 => return None,
+            25..=80 => 1,
+            81..=160 => 2,
             _ => 3,
         };
 
@@ -222,7 +222,7 @@ impl Engine {
                 if Some(m) == transposition.map(|t| t.best()) {
                     (m, Value::upper())
                 } else if Self::KILLERS.with_borrow(|ks| ks.contains(ply, pos.turn(), m)) {
-                    (m, Value::new(100))
+                    (m, Value::new(40))
                 } else if m.is_quiet() {
                     (m, Value::new(0))
                 } else {
@@ -308,7 +308,7 @@ impl Engine {
         'id: for d in depth.get()..=limit.get() {
             let mut overtime = time.end - time.start;
             let mut depth = Depth::new(d);
-            let mut delta: i16 = 24;
+            let mut delta: i16 = 10;
 
             let (mut lower, mut upper) = match d {
                 ..=4 => (Score::lower(), Score::upper()),

--- a/lib/search/ply.rs
+++ b/lib/search/ply.rs
@@ -11,7 +11,7 @@ unsafe impl Integer for PlyRepr {
     const MIN: Self::Repr = -Self::MAX;
 
     #[cfg(not(test))]
-    const MAX: Self::Repr = 127;
+    const MAX: Self::Repr = 95;
 
     #[cfg(test)]
     const MAX: Self::Repr = 3;

--- a/lib/search/score.rs
+++ b/lib/search/score.rs
@@ -10,7 +10,7 @@ pub struct ScoreRepr(#[cfg_attr(test, strategy(Self::MIN..=Self::MAX))] <Self as
 unsafe impl Integer for ScoreRepr {
     type Repr = i16;
     const MIN: Self::Repr = -Self::MAX;
-    const MAX: Self::Repr = 8191;
+    const MAX: Self::Repr = 4095;
 }
 
 /// The minimax score.
@@ -50,7 +50,7 @@ impl Perspective for Score {
 }
 
 impl Binary for Score {
-    type Bits = Bits<u16, 14>;
+    type Bits = Bits<u16, 13>;
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -102,7 +102,7 @@ impl Transposition {
 }
 
 impl Binary for Transposition {
-    type Bits = Bits<u64, 38>;
+    type Bits = Bits<u64, 37>;
 
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
@@ -125,7 +125,7 @@ impl Binary for Transposition {
     }
 }
 
-type Signature = Bits<u32, 26>;
+type Signature = Bits<u32, 27>;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -23       5    9000    2114    2710    4176   4202.0   46.7%   46.4% 
   1 Frozenight-6.0                 32       9    3000     939     665    1396   1637.0   54.6%   46.5% 
   2 Marvin-6.2                     21       9    3000     841     659    1500   1591.0   53.0%   50.0% 
   3 Halogen-11.0                   16       9    3000     930     790    1280   1570.0   52.3%   42.7%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:15s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     62     53     63     71     67     53     59     49     49     60     49     52     56     58     50    851
   Score   7455   6668   7472   8223   7811   7544   7100   6716   6096   7078   6242   6573   6654   7001   6630 105263
Score(%)   87.7   83.3   86.9   92.4   91.9   94.3   86.6   84.0   85.9   89.6   89.2   88.8   88.7   88.6   90.8   88.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.3%, "Re-Capturing"
2. STS 04, 92.4%, "Square Vacancy"
3. STS 05, 91.9%, "Bishop vs Knight"
4. STS 15, 90.8%, "Avoid Pointless Exchange"
5. STS 10, 89.6%, "Simplification"

:: Top 5 STS with low result ::
1. STS 02, 83.3%, "Open Files and Diagonals"
2. STS 08, 84.0%, "Advancement of f/g/h Pawns"
3. STS 09, 85.9%, "Advancement of a/b/c Pawns"
4. STS 07, 86.6%, "Offer of Simplification"
5. STS 03, 86.9%, "Knight Outposts"
```