### PR TITLE
Address newest Clippy warnings

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -13,7 +13,7 @@ use std::{str::FromStr, thread::available_parallelism};
 static POSITION: Evaluator =
     Evaluator::from_str("6br/1KNp1n1r/2p2p2/P1ppRP2/1kP3pP/3PBB2/PN1P4/8 w - - 0 1").unwrap();
 
-fn bench(reps: u64, options: Options, limits: Limits) -> Duration {
+fn bench(reps: u64, options: &Options, limits: &Limits) -> Duration {
     let mut time = Duration::ZERO;
 
     for _ in 0..reps {
@@ -39,22 +39,22 @@ fn crit(c: &mut Criterion) {
         ..Options::default()
     }));
 
-    for &o in &options {
+    for o in &options {
         let depth = Depth::new(12);
         c.benchmark_group("ttd")
             .sampling_mode(SamplingMode::Flat)
             .bench_function(o.threads.to_string(), |b| {
-                b.iter_custom(|i| bench(i, o, depth.into()))
+                b.iter_custom(|i| bench(i, o, &depth.into()))
             });
     }
 
-    for &o in &options {
+    for o in &options {
         let nodes = 300_000;
         c.benchmark_group("nps")
             .sampling_mode(SamplingMode::Flat)
             .throughput(Throughput::Elements(nodes))
             .bench_function(o.threads.to_string(), |b| {
-                b.iter_custom(|i| bench(i, o, nodes.into()))
+                b.iter_custom(|i| bench(i, o, &nodes.into()))
             });
     }
 }

--- a/lib/chess/board.rs
+++ b/lib/chess/board.rs
@@ -132,7 +132,7 @@ impl Board {
     /// Toggles a piece on a square.
     #[inline(always)]
     pub fn toggle(&mut self, p: Piece, sq: Square) {
-        debug_assert!(!self[sq].is_some_and(|q| p != q));
+        debug_assert!(self[sq].is_none_or(|q| p == q));
         self.colors[p.color() as usize] ^= sq.bitboard();
         self.roles[p.role() as usize] ^= sq.bitboard();
     }

--- a/lib/chess/board.rs
+++ b/lib/chess/board.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Write};
 use std::{ops::Index, str::FromStr};
 
 /// The chess board.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[debug("Board({self})")]
 pub struct Board {

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -70,7 +70,7 @@ impl Move {
     #[inline(always)]
     pub fn set_whence(&mut self, whence: Square) {
         let bits = self.0.get() & 0b0000001111111111 | ((whence as u16) << 10);
-        self.0 = NonZeroU16::new(bits).assume();
+        self.0 = <NonZeroU16 as Integer>::new(bits);
     }
 
     /// The destination [`Square`].
@@ -83,7 +83,7 @@ impl Move {
     #[inline(always)]
     pub fn set_whither(&mut self, whither: Square) {
         let bits = (self.0.get() & 0b1111110000001111) | ((whither as u16) << 4);
-        self.0 = NonZeroU16::new(bits).assume();
+        self.0 = <NonZeroU16 as Integer>::new(bits);
     }
 
     /// The promotion specifier.
@@ -101,7 +101,7 @@ impl Move {
     pub fn set_promotion(&mut self, promotion: Role) {
         debug_assert!(self.is_promotion());
         let bits = (self.0.get() & 0b1111111111111100) | (promotion as u16 - 1);
-        self.0 = NonZeroU16::new(bits).assume();
+        self.0 = <NonZeroU16 as Integer>::new(bits);
     }
 
     /// Whether this is a castling move.

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -1,5 +1,12 @@
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_mm_shuffle))]
-#![feature(array_chunks, coverage_attribute, new_zeroed_alloc, optimize_attribute)]
+#![feature(
+    array_chunks,
+    coverage_attribute,
+    new_zeroed_alloc,
+    optimize_attribute,
+    ptr_as_ref_unchecked,
+    sync_unsafe_cell
+)]
 
 /// Chess domain types.
 pub mod chess;

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -26,7 +26,7 @@ pub use value::*;
 /// An [Efficiently Updatable Neural Network][NNUE].
 ///
 /// [NNUE]: https://www.chessprogramming.org/NNUE
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 struct Nnue {
     ft: Transformer<i16, { Positional::LEN }>,
     psqt: Transformer<i32, { Material::LEN }>,

--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -12,14 +12,14 @@ use proptest::prelude::*;
 #[derive(Debug, Display, Clone, Eq, PartialEq, Hash, Deref)]
 #[debug("Evaluator({self})")]
 #[display("{pos}")]
-pub struct Evaluator<T: Copy + Accumulator = (Material, Positional)> {
+pub struct Evaluator<T: Accumulator = (Material, Positional)> {
     #[deref]
     pos: Position,
     acc: T,
 }
 
 #[cfg(test)]
-impl<T: 'static + Copy + Accumulator> Arbitrary for Evaluator<T> {
+impl<T: 'static + Accumulator> Arbitrary for Evaluator<T> {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
 
@@ -34,7 +34,7 @@ impl Default for Evaluator {
     }
 }
 
-impl<T: Copy + Accumulator> Evaluator<T> {
+impl<T: Accumulator> Evaluator<T> {
     /// Constructs the evaluator from a [`Position`].
     pub fn new(pos: Position) -> Self {
         let mut acc = T::default();
@@ -146,16 +146,16 @@ impl Evaluator {
     /// The [`Position`]'s material evaluator.
     pub fn material(&self) -> Evaluator<Material> {
         Evaluator {
-            pos: self.pos,
-            acc: self.acc.0,
+            pos: self.pos.clone(),
+            acc: self.acc.0.clone(),
         }
     }
 
     /// The [`Position`]'s positional evaluator.
     pub fn positional(&self) -> Evaluator<Positional> {
         Evaluator {
-            pos: self.pos,
-            acc: self.acc.1,
+            pos: self.pos.clone(),
+            acc: self.acc.1.clone(),
         }
     }
 }
@@ -194,7 +194,7 @@ mod tests {
         #[filter(#e.outcome().is_none())] mut e: Evaluator,
         #[map(|sq: Selector| sq.select(#e.moves().flatten()))] m: Move,
     ) {
-        let mut pos = e.pos;
+        let mut pos = e.pos.clone();
         e.play(m);
         pos.play(m);
         assert_eq!(e, Evaluator::new(pos));
@@ -202,7 +202,7 @@ mod tests {
 
     #[proptest]
     fn pass_updates_evaluator(#[filter(!#e.is_check())] mut e: Evaluator) {
-        let mut pos = e.pos;
+        let mut pos = e.pos.clone();
         e.pass();
         pos.pass();
         assert_eq!(e, Evaluator::new(pos));

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Color, Perspective};
 use crate::nnue::{Accumulator, Feature, Nnue};
-use crate::util::AlignTo64;
+use crate::util::{AlignTo64, Assume};
 use derive_more::Debug;
 
 /// An accumulator for the psqt transformer.
@@ -44,7 +44,9 @@ impl Accumulator for Material {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        (self.0[turn as usize][phase] - self.0[turn.flip() as usize][phase]) / 80
+        let us = self.0[turn as usize];
+        let them = self.0[turn.flip() as usize];
+        (us.get(phase).assume() - them.get(phase).assume()) / 80
     }
 }
 

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -4,7 +4,7 @@ use crate::util::{AlignTo64, Assume};
 use derive_more::Debug;
 
 /// An accumulator for the psqt transformer.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[debug("Positional")]
 pub struct Material(
@@ -64,7 +64,7 @@ mod tests {
 
     #[proptest]
     fn remove_reverses_add(a: Material, c: Color, f: Feature) {
-        let mut b = a;
+        let mut b = a.clone();
         b.add(c, f);
         b.remove(c, f);
         assert_eq!(a, b);
@@ -72,7 +72,7 @@ mod tests {
 
     #[proptest]
     fn replace_reverses_itself(a: Material, c: Color, x: Feature, y: Feature) {
-        let mut b = a;
+        let mut b = a.clone();
         b.replace(c, x, y);
         b.replace(c, y, x);
         assert_eq!(a, b);

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -4,7 +4,7 @@ use crate::util::AlignTo64;
 use derive_more::Debug;
 
 /// An accumulator for the feature transformer.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[debug("Positional")]
 pub struct Positional(
@@ -44,7 +44,7 @@ impl Accumulator for Positional {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        Nnue::hidden(phase).forward([&self.0[turn as usize], &self.0[turn.flip() as usize]]) / 40
+        Nnue::hidden(phase).forward(&self.0[turn as usize], &self.0[turn.flip() as usize]) / 40
     }
 }
 
@@ -57,7 +57,7 @@ mod tests {
 
     #[proptest]
     fn remove_reverses_add(a: Positional, c: Color, f: Feature) {
-        let mut b = a;
+        let mut b = a.clone();
         b.add(c, f);
         b.remove(c, f);
         assert_eq!(a, b);
@@ -65,7 +65,7 @@ mod tests {
 
     #[proptest]
     fn replace_reverses_itself(a: Positional, c: Color, x: Feature, y: Feature) {
-        let mut b = a;
+        let mut b = a.clone();
         b.replace(c, x, y);
         b.replace(c, y, x);
         assert_eq!(a, b);

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -10,7 +10,7 @@ use proptest::{prelude::*, sample::Index};
 use std::ops::Range;
 
 /// A feature transformer.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Constructor)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Constructor)]
 pub struct Transformer<T, const N: usize> {
     pub(super) bias: AlignTo64<[T; N]>,
     pub(super) weight: AlignTo64<[[T; N]; Feature::LEN]>,

--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -14,7 +14,7 @@ pub enum Control<'a> {
     Limited(Counter, Timer, &'a Trigger),
 }
 
-impl<'a> Control<'a> {
+impl Control<'_> {
     /// A reference to the timer.
     #[inline(always)]
     pub fn timer(&self) -> &Timer {

--- a/lib/search/driver.rs
+++ b/lib/search/driver.rs
@@ -5,7 +5,7 @@ use rayon::{prelude::*, ThreadPool, ThreadPoolBuilder};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Whether the search should be [`Interrupted`] or exited early.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
 pub enum ControlFlow {
     Interrupt(Interrupted),
     Break,
@@ -68,7 +68,7 @@ impl Driver {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 struct IndexedPv(#[deref] Pv, u32);
 

--- a/lib/search/killers.rs
+++ b/lib/search/killers.rs
@@ -4,7 +4,7 @@ use crate::{search::Ply, util::Integer};
 /// A set of [killer moves] indexed by [`Ply`] and side to move.
 ///
 /// [killer moves]: https://www.chessprogramming.org/Killer_Move
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Killers<const P: usize>([[[Option<Move>; 2]; 2]; P]);
 
@@ -85,7 +85,7 @@ mod tests {
         c: Color,
         m: Move,
     ) {
-        let prev = ks;
+        let prev = ks.clone();
         ks.insert(p, c, m);
         assert_eq!(ks, prev);
     }

--- a/lib/search/limits.rs
+++ b/lib/search/limits.rs
@@ -3,7 +3,7 @@ use derive_more::From;
 use std::time::Duration;
 
 /// Configuration for search limits.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, From)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, From)]
 pub enum Limits {
     /// Unlimited search.
     #[default]

--- a/lib/search/options.rs
+++ b/lib/search/options.rs
@@ -120,7 +120,7 @@ impl FromStr for ThreadCount {
 }
 
 /// Configuration for adversarial search algorithms.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Options {
     /// The size of the transposition table in bytes.

--- a/lib/util/assume.rs
+++ b/lib/util/assume.rs
@@ -10,55 +10,21 @@ pub trait Assume {
 impl<T> Assume for Option<T> {
     type Assumed = T;
 
-    #[inline]
     #[track_caller]
+    #[inline(always)]
     fn assume(self) -> Self::Assumed {
-        match self {
-            Some(v) => v,
-
-            #[cfg(not(debug_assertions))]
-            // Definitely not safe, but we'll assume unit tests will catch everything.
-            _ => unsafe { std::hint::unreachable_unchecked() },
-
-            #[cfg(debug_assertions)]
-            _ => unreachable!(),
-        }
+        // Definitely not safe, but we'll assume unit tests will catch everything.
+        unsafe { self.unwrap_unchecked() }
     }
 }
 
 impl<T, E> Assume for Result<T, E> {
     type Assumed = T;
 
-    #[inline]
     #[track_caller]
+    #[inline(always)]
     fn assume(self) -> Self::Assumed {
-        match self {
-            Ok(v) => v,
-
-            #[cfg(not(debug_assertions))]
-            // Definitely not safe, but we'll assume unit tests will catch everything.
-            _ => unsafe { std::hint::unreachable_unchecked() },
-
-            #[cfg(debug_assertions)]
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_strategy::proptest;
-
-    #[test]
-    #[should_panic]
-    fn assuming_none_panics() {
-        None.assume()
-    }
-
-    #[proptest]
-    #[should_panic]
-    fn assuming_err_panics(i: i8) {
-        Err(i).assume()
+        // Definitely not safe, but we'll assume unit tests will catch everything.
+        unsafe { self.unwrap_unchecked() }
     }
 }

--- a/lib/util/integer.rs
+++ b/lib/util/integer.rs
@@ -167,12 +167,7 @@ macro_rules! impl_primitive_for {
                         32 => (self as i32).cast(),
                         64 => (self as i64).cast(),
                         128 => (self as i128).cast(),
-
-                        #[cfg(not(debug_assertions))]
                         _ => unsafe { std::hint::unreachable_unchecked() },
-
-                        #[cfg(debug_assertions)]
-                        _ => unreachable!(),
                     }
                 }
             }

--- a/tests/perft.rs
+++ b/tests/perft.rs
@@ -2,7 +2,7 @@ use lib::chess::Position;
 use rayon::prelude::*;
 use test_strategy::proptest;
 
-fn perft(pos: Position, depth: u8) -> usize {
+fn perft(pos: &Position, depth: u8) -> usize {
     match depth {
         0 => 1,
         1 => pos.moves().flatten().count(),
@@ -11,9 +11,9 @@ fn perft(pos: Position, depth: u8) -> usize {
             .flatten()
             .par_bridge()
             .map(|m| {
-                let mut next = pos;
+                let mut next = pos.clone();
                 next.play(m);
-                perft(next, d - 1)
+                perft(&next, d - 1)
             })
             .sum(),
     }
@@ -23,25 +23,25 @@ fn perft(pos: Position, depth: u8) -> usize {
 #[proptest(cases = 1)]
 fn perft_expands_expected_number_of_nodes() {
     // https://www.chessprogramming.org/Perft_Results#Initial_Position
-    assert_eq!(perft(Position::default(), 5), 4865609);
+    assert_eq!(perft(&Position::default(), 5), 4865609);
 
     // https://www.chessprogramming.org/Perft_Results#Position_2
     let pos = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1".parse()?;
-    assert_eq!(perft(pos, 5), 193690690);
+    assert_eq!(perft(&pos, 5), 193690690);
 
     // https://www.chessprogramming.org/Perft_Results#Position_3
     let pos = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1".parse()?;
-    assert_eq!(perft(pos, 5), 674624);
+    assert_eq!(perft(&pos, 5), 674624);
 
     // https://www.chessprogramming.org/Perft_Results#Position_4
     let pos = "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1".parse()?;
-    assert_eq!(perft(pos, 5), 15833292);
+    assert_eq!(perft(&pos, 5), 15833292);
 
     // https://www.chessprogramming.org/Perft_Results#Position_5
     let pos = "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8".parse()?;
-    assert_eq!(perft(pos, 5), 89941194);
+    assert_eq!(perft(&pos, 5), 89941194);
 
     // https://www.chessprogramming.org/Perft_Results#Position_6
     let pos = "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10".parse()?;
-    assert_eq!(perft(pos, 5), 164075551);
+    assert_eq!(perft(&pos, 5), 164075551);
 }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -13       5    9000    2219    2554    4227   4332.5   48.1%   47.0% 
   1 Frozenight-6.0                 18       9    3000     883     732    1385   1575.5   52.5%   46.2% 
   2 Marvin-6.2                     16       9    3000     806     671    1523   1567.5   52.3%   50.8% 
   3 Halogen-11.0                    6       9    3000     865     816    1319   1524.5   50.8%   44.0%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     60     62     68     67     55     58     52     49     58     50     50     57     58     51    863
   Score   7818   6911   7459   8167   8000   7564   7073   6698   6127   7153   6323   6487   6725   7026   6468 105999
Score(%)   92.0   86.4   86.7   91.8   94.1   94.5   86.3   83.7   86.3   90.5   90.3   87.7   89.7   88.9   88.6   89.2

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.5%, "Re-Capturing"
2. STS 05, 94.1%, "Bishop vs Knight"
3. STS 01, 92.0%, "Undermining"
4. STS 04, 91.8%, "Square Vacancy"
5. STS 10, 90.5%, "Simplification"

:: Top 5 STS with low result ::
1. STS 08, 83.7%, "Advancement of f/g/h Pawns"
2. STS 07, 86.3%, "Offer of Simplification"
3. STS 09, 86.3%, "Advancement of a/b/c Pawns"
4. STS 02, 86.4%, "Open Files and Diagonals"
5. STS 03, 86.7%, "Knight Outposts"
```