### PR TITLE
Scale evaluation down by 1.6

### DIFF
--- a/lib/nnue/evaluator.rs
+++ b/lib/nnue/evaluator.rs
@@ -51,7 +51,8 @@ impl<T: Accumulator> Evaluator<T> {
     /// The [`Position`]'s evaluation.
     pub fn evaluate(&self) -> Value {
         let phase = (self.occupied().len() - 1) / 4;
-        self.acc.evaluate(self.turn(), phase).saturate()
+        let value = self.acc.evaluate(self.turn(), phase) >> 7;
+        value.saturate()
     }
 
     /// The Static Exchange Evaluation ([SEE]) algorithm.

--- a/lib/nnue/material.rs
+++ b/lib/nnue/material.rs
@@ -44,9 +44,7 @@ impl Accumulator for Material {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        let us = self.0[turn as usize];
-        let them = self.0[turn.flip() as usize];
-        (us.get(phase).assume() - them.get(phase).assume()) / 80
+        self.0[turn as usize].get(phase).assume() - self.0[turn.flip() as usize].get(phase).assume()
     }
 }
 

--- a/lib/nnue/positional.rs
+++ b/lib/nnue/positional.rs
@@ -44,7 +44,7 @@ impl Accumulator for Positional {
 
     #[inline(always)]
     fn evaluate(&self, turn: Color, phase: usize) -> i32 {
-        Nnue::hidden(phase).forward(&self.0[turn as usize], &self.0[turn.flip() as usize]) / 40
+        Nnue::hidden(phase).forward(&self.0[turn as usize], &self.0[turn.flip() as usize]) << 1
     }
 }
 

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -103,11 +103,10 @@ impl Engine {
         depth: Depth,
         ply: Ply,
     ) -> Option<Depth> {
-        let bounds = -(alpha - 24)..-(alpha - 161);
-        let r = match (alpha + next.clone().see(m.whither(), bounds)).get() {
-            ..=24 => return None,
-            25..=80 => 1,
-            81..=160 => 2,
+        let r = match (alpha + next.clone().see(m.whither(), -(alpha - 15)..-(alpha - 101))).get() {
+            ..=15 => return None,
+            16..=50 => 1,
+            51..=100 => 2,
             _ => 3,
         };
 
@@ -223,7 +222,7 @@ impl Engine {
                 if Some(m) == transposition.map(|t| t.best()) {
                     (m, Value::upper())
                 } else if Self::KILLERS.with_borrow(|ks| ks.contains(ply, pos.turn(), m)) {
-                    (m, Value::new(40))
+                    (m, Value::new(25))
                 } else if m.is_quiet() {
                     (m, Value::new(0))
                 } else {
@@ -309,7 +308,7 @@ impl Engine {
         'id: for d in depth.get()..=limit.get() {
             let mut overtime = time.end - time.start;
             let mut depth = Depth::new(d);
-            let mut delta: i16 = 10;
+            let mut delta: i16 = 5;
 
             let (mut lower, mut upper) = match d {
                 ..=4 => (Score::lower(), Score::upper()),


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 8 -ratinginterval 10 -resultformat wide -recover -tb engines/syzygy/ -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            -4       5    9000    2450    2545    4005   4452.5   49.5%   44.5%
   1 Frozenight-6.0                 14       9    3000     880     758    1362   1561.0   52.0%   45.4%
   2 Halogen-11.0                   -1       9    3000     866     876    1258   1495.0   49.8%   41.9%
   3 Marvin-6.2                     -2       9    3000     799     816    1385   1491.5   49.7%   46.2%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     65     60     60     72     68     53     58     56     49     61     47     51     59     60     51    870
   Score   7633   7180   7227   8383   8040   7487   7215   6799   6142   7356   6087   6469   6803   7194   6613 106628
Score(%)   89.8   89.8   84.0   94.2   94.6   93.6   88.0   85.0   86.5   93.1   87.0   87.4   90.7   91.1   90.6   89.8

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 94.6%, "Bishop vs Knight"
2. STS 04, 94.2%, "Square Vacancy"
3. STS 06, 93.6%, "Re-Capturing"
4. STS 10, 93.1%, "Simplification"
5. STS 14, 91.1%, "Queens and Rooks to the 7th rank"

:: Top 5 STS with low result ::
1. STS 03, 84.0%, "Knight Outposts"
2. STS 08, 85.0%, "Advancement of f/g/h Pawns"
3. STS 09, 86.5%, "Advancement of a/b/c Pawns"
4. STS 11, 87.0%, "Activity of the King"
5. STS 12, 87.4%, "Center Control"
```