### PR TITLE
Reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,11 @@ criterion-macro = { version = "0.4.0", default-features = false }
 proptest = { version = "1.5.0", default-features = false, features = ["std"] }
 test-strategy = { version = "0.4.0", default-features = false }
 
-[profile.release.package.ruzstd]
-opt-level = 's'
-
 [profile.release]
 codegen-units = 1
-lto = true
 panic = "abort"
-strip = "symbols"
+lto = true
+strip = true
 
 [profile.dev]
 opt-level = 3

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,36 +1,21 @@
-use futures::executor::{block_on, block_on_stream};
-use futures::{channel::mpsc, prelude::*};
+use futures::executor::block_on;
+use futures::{channel::mpsc::unbounded, sink::unfold};
 use lib::uci::Uci;
-use std::io::{prelude::*, stdin, stdout, LineWriter};
-use std::thread;
+use std::io::{prelude::*, stdin, stdout};
+use std::{future::ready, thread};
 
 fn main() {
-    let (mut tx, input) = mpsc::channel(32);
-    let (output, rx) = mpsc::channel(32);
+    let (tx, rx) = unbounded();
 
     thread::spawn(move || {
-        for item in stdin().lock().lines() {
-            match item {
-                Err(error) => return eprint!("{error}"),
-                Ok(line) => {
-                    if let Err(error) = block_on(tx.send(line)) {
-                        if error.is_disconnected() {
-                            break;
-                        }
-                    }
-                }
+        for line in stdin().lock().lines() {
+            if tx.unbounded_send(line.unwrap()).is_err() {
+                break;
             }
         }
     });
 
-    thread::spawn(move || {
-        let mut stdout = LineWriter::new(stdout().lock());
-        for line in block_on_stream(rx) {
-            if let Err(error) = writeln!(stdout, "{line}") {
-                return eprint!("{error}");
-            }
-        }
-    });
-
-    block_on(Uci::new(input, output).run()).ok();
+    let mut stdout = stdout().lock();
+    let output = unfold((), |_, line: String| ready(writeln!(stdout, "{line}")));
+    block_on(Uci::new(rx, output).run()).unwrap();
 }

--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -1,7 +1,7 @@
 use crate::chess::{File, Perspective, Rank, Square};
 use crate::util::{Assume, Integer};
 use derive_more::{Debug, *};
-use std::fmt::{self, Write};
+use std::fmt::{self, Formatter, Write};
 use std::{cell::SyncUnsafeCell, mem::MaybeUninit};
 
 /// A set of squares on a chess board.
@@ -26,9 +26,9 @@ use std::{cell::SyncUnsafeCell, mem::MaybeUninit};
 #[repr(transparent)]
 pub struct Bitboard(u64);
 
-impl fmt::Debug for Bitboard {
+impl Debug for Bitboard {
     #[coverage(off)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_char('\n')?;
         for rank in Rank::iter().rev() {
             for file in File::iter() {

--- a/lib/chess/castles.rs
+++ b/lib/chess/castles.rs
@@ -1,7 +1,8 @@
 use crate::chess::{Color, Perspective, Piece, Role, Square};
 use crate::util::{Bits, Integer};
 use derive_more::{Debug, *};
-use std::{cell::SyncUnsafeCell, fmt, mem::MaybeUninit, str::FromStr};
+use std::fmt::{self, Formatter};
+use std::{cell::SyncUnsafeCell, mem::MaybeUninit, str::FromStr};
 
 /// The castling rights in a chess [`Position`][`crate::chess::Position`].
 #[derive(
@@ -107,15 +108,15 @@ impl From<Square> for Castles {
     }
 }
 
-impl fmt::Display for Castles {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for Castles {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         for side in Color::iter() {
             if self.has_short(side) {
-                fmt::Display::fmt(&Piece::new(Role::King, side), f)?;
+                Display::fmt(&Piece::new(Role::King, side), f)?;
             }
 
             if self.has_long(side) {
-                fmt::Display::fmt(&Piece::new(Role::Queen, side), f)?;
+                Display::fmt(&Piece::new(Role::Queen, side), f)?;
             }
         }
 
@@ -131,6 +132,7 @@ pub struct ParseCastlesError;
 impl FromStr for Castles {
     type Err = ParseCastlesError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut castles = Castles::none();
 

--- a/lib/chess/file.rs
+++ b/lib/chess/file.rs
@@ -1,28 +1,21 @@
 use crate::chess::{Bitboard, Mirror};
 use crate::util::Integer;
 use derive_more::{Display, Error};
+use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
 
 /// A column on the chess board.
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 pub enum File {
-    #[display("a")]
     A,
-    #[display("b")]
     B,
-    #[display("c")]
     C,
-    #[display("d")]
     D,
-    #[display("e")]
     E,
-    #[display("f")]
     F,
-    #[display("g")]
     G,
-    #[display("h")]
     H,
 }
 
@@ -57,30 +50,29 @@ impl Sub for File {
     }
 }
 
+impl Display for File {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_char((b'a' + self.cast::<u8>()).into())
+    }
+}
+
 /// The reason why parsing [`File`] failed.
 #[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
-#[display(
-    "failed to parse file, expected letter in the range `({}..={})`",
-    File::A,
-    File::H
-)]
+#[display("failed to parse file")]
 pub struct ParseFileError;
 
 impl FromStr for File {
     type Err = ParseFileError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "a" => Ok(File::A),
-            "b" => Ok(File::B),
-            "c" => Ok(File::C),
-            "d" => Ok(File::D),
-            "e" => Ok(File::E),
-            "f" => Ok(File::F),
-            "g" => Ok(File::G),
-            "h" => Ok(File::H),
-            _ => Err(ParseFileError),
-        }
+        let [c] = s.as_bytes() else {
+            return Err(ParseFileError);
+        };
+
+        c.checked_sub(b'a')
+            .and_then(Integer::convert)
+            .ok_or(ParseFileError)
     }
 }
 

--- a/lib/chess/magic.rs
+++ b/lib/chess/magic.rs
@@ -4,14 +4,17 @@ use crate::chess::{Bitboard, Square};
 pub struct Magic(Bitboard, u64, usize);
 
 impl Magic {
+    #[inline(always)]
     pub fn mask(&self) -> Bitboard {
         self.0
     }
 
+    #[inline(always)]
     pub fn factor(&self) -> u64 {
         self.1
     }
 
+    #[inline(always)]
     pub fn offset(&self) -> usize {
         self.2
     }

--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -1,6 +1,6 @@
 use crate::chess::{Bitboard, Perspective, Piece, Rank, Role, Square, Squares};
 use crate::util::{Assume, Binary, Bits, Integer};
-use std::fmt::{self, Write};
+use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::{num::NonZeroU16, ops::RangeBounds};
 
 /// A chess move.
@@ -135,10 +135,10 @@ impl Move {
     }
 }
 
-impl fmt::Debug for Move {
+impl Debug for Move {
     #[coverage(off)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)?;
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self, f)?;
 
         if self.is_en_passant() {
             f.write_char('^')?;
@@ -152,13 +152,13 @@ impl fmt::Debug for Move {
     }
 }
 
-impl fmt::Display for Move {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.whence(), f)?;
-        fmt::Display::fmt(&self.whither(), f)?;
+impl Display for Move {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.whence(), f)?;
+        Display::fmt(&self.whither(), f)?;
 
         if let Some(r) = self.promotion() {
-            fmt::Display::fmt(&r, f)?;
+            Display::fmt(&r, f)?;
         }
 
         Ok(())

--- a/lib/chess/outcome.rs
+++ b/lib/chess/outcome.rs
@@ -25,16 +25,19 @@ impl Outcome {
     /// Whether the outcome is a [draw] and neither side has won.
     ///
     /// [draw]: https://www.chessprogramming.org/Draw
+    #[inline(always)]
     pub fn is_draw(&self) -> bool {
         !self.is_decisive()
     }
 
     /// Whether the outcome is a decisive and one of the sides has won.
+    #[inline(always)]
     pub fn is_decisive(&self) -> bool {
         matches!(self, Outcome::Checkmate(_))
     }
 
     /// The winning side, if the outcome is [decisive](`Self::is_decisive`).
+    #[inline(always)]
     pub fn winner(&self) -> Option<Color> {
         match *self {
             Outcome::Checkmate(c) => Some(c),

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -1,36 +1,25 @@
 use crate::chess::{Bitboard, Color, Magic, Perspective, Role, Square};
 use crate::util::{Assume, Integer};
 use derive_more::{Display, Error};
+use std::fmt::{self, Formatter, Write};
 use std::{cell::SyncUnsafeCell, mem::MaybeUninit, str::FromStr};
 
 /// A chess [piece][`Role`] of a certain [`Color`].
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Piece {
-    #[display("P")]
     WhitePawn,
-    #[display("p")]
     BlackPawn,
-    #[display("N")]
     WhiteKnight,
-    #[display("n")]
     BlackKnight,
-    #[display("B")]
     WhiteBishop,
-    #[display("b")]
     BlackBishop,
-    #[display("R")]
     WhiteRook,
-    #[display("r")]
     BlackRook,
-    #[display("Q")]
     WhiteQueen,
-    #[display("q")]
     BlackQueen,
-    #[display("K")]
     WhiteKing,
-    #[display("k")]
     BlackKing,
 }
 
@@ -201,28 +190,34 @@ impl Perspective for Piece {
     }
 }
 
+impl Display for Piece {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Piece::WhitePawn => f.write_char('P'),
+            Piece::BlackPawn => f.write_char('p'),
+            Piece::WhiteKnight => f.write_char('N'),
+            Piece::BlackKnight => f.write_char('n'),
+            Piece::WhiteBishop => f.write_char('B'),
+            Piece::BlackBishop => f.write_char('b'),
+            Piece::WhiteRook => f.write_char('R'),
+            Piece::BlackRook => f.write_char('r'),
+            Piece::WhiteQueen => f.write_char('Q'),
+            Piece::BlackQueen => f.write_char('q'),
+            Piece::WhiteKing => f.write_char('K'),
+            Piece::BlackKing => f.write_char('k'),
+        }
+    }
+}
+
 /// The reason why parsing the piece.
 #[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
-#[display(
-    "failed to parse piece, expected one of `[{}{}{}{}{}{}{}{}{}{}{}{}]`",
-    Piece::WhitePawn,
-    Piece::BlackPawn,
-    Piece::WhiteKnight,
-    Piece::BlackKnight,
-    Piece::WhiteBishop,
-    Piece::BlackBishop,
-    Piece::WhiteRook,
-    Piece::BlackRook,
-    Piece::WhiteQueen,
-    Piece::BlackQueen,
-    Piece::WhiteKing,
-    Piece::BlackKing
-)]
+#[display("failed to parse piece")]
 pub struct ParsePieceError;
 
 impl FromStr for Piece {
     type Err = ParsePieceError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "P" => Ok(Piece::WhitePawn),

--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -2,8 +2,9 @@ use crate::chess::*;
 use crate::util::{Assume, Integer};
 use arrayvec::{ArrayVec, CapacityError};
 use derive_more::{Debug, Display, Error, From};
+use std::fmt::{self, Formatter};
 use std::hash::{Hash, Hasher};
-use std::{fmt, num::NonZeroU32, str::FromStr};
+use std::{num::NonZeroU32, str::FromStr};
 
 #[cfg(test)]
 use proptest::{prelude::*, sample::*};
@@ -617,9 +618,8 @@ impl Position {
 }
 
 impl Display for Position {
-    #[inline(always)]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.board, f)
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.board, f)
     }
 }
 
@@ -635,6 +635,7 @@ pub enum ParsePositionError {
 impl FromStr for Position {
     type Err = ParsePositionError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use {ParsePositionError::*, Role::*};
 

--- a/lib/chess/rank.rs
+++ b/lib/chess/rank.rs
@@ -1,28 +1,21 @@
 use crate::chess::{Bitboard, Perspective};
 use crate::util::Integer;
 use derive_more::{Display, Error};
+use std::fmt::{self, Formatter, Write};
 use std::{ops::Sub, str::FromStr};
 
 /// A row on the chess board.
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(i8)]
 pub enum Rank {
-    #[display("1")]
     First,
-    #[display("2")]
     Second,
-    #[display("3")]
     Third,
-    #[display("4")]
     Fourth,
-    #[display("5")]
     Fifth,
-    #[display("6")]
     Sixth,
-    #[display("7")]
     Seventh,
-    #[display("8")]
     Eighth,
 }
 
@@ -57,30 +50,29 @@ impl Sub for Rank {
     }
 }
 
+impl Display for Rank {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_char((b'1' + self.cast::<u8>()).into())
+    }
+}
+
 /// The reason why parsing [`Rank`] failed.
 #[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
-#[display(
-    "failed to parse rank, expected digit in the range `({}..={})`",
-    Rank::First,
-    Rank::Eighth
-)]
+#[display("failed to parse rank")]
 pub struct ParseRankError;
 
 impl FromStr for Rank {
     type Err = ParseRankError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "1" => Ok(Rank::First),
-            "2" => Ok(Rank::Second),
-            "3" => Ok(Rank::Third),
-            "4" => Ok(Rank::Fourth),
-            "5" => Ok(Rank::Fifth),
-            "6" => Ok(Rank::Sixth),
-            "7" => Ok(Rank::Seventh),
-            "8" => Ok(Rank::Eighth),
-            _ => Err(ParseRankError),
-        }
+        let [c] = s.as_bytes() else {
+            return Err(ParseRankError);
+        };
+
+        c.checked_sub(b'1')
+            .and_then(Integer::convert)
+            .ok_or(ParseRankError)
     }
 }
 

--- a/lib/chess/role.rs
+++ b/lib/chess/role.rs
@@ -1,23 +1,18 @@
 use crate::util::Integer;
 use derive_more::{Display, Error};
+use std::fmt::{self, Formatter, Write};
 use std::str::FromStr;
 
 /// The type of a chess [`Piece`][`crate::Piece`].
-#[derive(Debug, Display, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[repr(u8)]
 pub enum Role {
-    #[display("p")]
     Pawn,
-    #[display("n")]
     Knight,
-    #[display("b")]
     Bishop,
-    #[display("r")]
     Rook,
-    #[display("q")]
     Queen,
-    #[display("k")]
     King,
 }
 
@@ -27,22 +22,28 @@ unsafe impl Integer for Role {
     const MAX: Self::Repr = Role::King as _;
 }
 
+impl Display for Role {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Role::Pawn => f.write_char('p'),
+            Role::Knight => f.write_char('n'),
+            Role::Bishop => f.write_char('b'),
+            Role::Rook => f.write_char('r'),
+            Role::Queen => f.write_char('q'),
+            Role::King => f.write_char('k'),
+        }
+    }
+}
+
 /// The reason why parsing the piece.
 #[derive(Debug, Display, Clone, Eq, PartialEq, Error)]
-#[display(
-    "failed to parse piece, expected one of `[{}{}{}{}{}{}]`",
-    Role::Pawn,
-    Role::Knight,
-    Role::Bishop,
-    Role::Rook,
-    Role::Queen,
-    Role::King
-)]
+#[display("failed to parse piece")]
 pub struct ParseRoleError;
 
 impl FromStr for Role {
     type Err = ParseRoleError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "p" => Ok(Role::Pawn),

--- a/lib/chess/square.rs
+++ b/lib/chess/square.rs
@@ -1,8 +1,9 @@
 use crate::chess::{Bitboard, File, Mirror, ParseFileError, ParseRankError, Perspective, Rank};
 use crate::util::{Assume, Binary, Bits, Integer};
 use derive_more::{Display, Error, From};
+use std::fmt::{self, Formatter};
 use std::ops::{Add, AddAssign, Sub, SubAssign};
-use std::{fmt, str::FromStr};
+use std::str::FromStr;
 
 /// A square on the chess board.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -123,10 +124,10 @@ impl AddAssign<i8> for Square {
     }
 }
 
-impl fmt::Display for Square {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.file(), f)?;
-        fmt::Display::fmt(&self.rank(), f)?;
+impl Display for Square {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.file(), f)?;
+        Display::fmt(&self.rank(), f)?;
         Ok(())
     }
 }
@@ -143,8 +144,9 @@ pub enum ParseSquareError {
 impl FromStr for Square {
     type Err = ParseSquareError;
 
+    #[inline(always)]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let i = s.char_indices().nth(1).map_or_else(|| s.len(), |(i, _)| i);
+        let i = s.ceil_char_boundary(1);
         Ok(Square::new(s[..i].parse()?, s[i..].parse()?))
     }
 }

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -2,6 +2,7 @@
 #![feature(
     array_chunks,
     coverage_attribute,
+    round_char_boundary,
     new_zeroed_alloc,
     optimize_attribute,
     ptr_as_ref_unchecked,

--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -1,8 +1,8 @@
 use crate::util::AlignTo64;
-use derive_more::{Constructor, Shl};
+use std::ops::Shl;
 
 /// The hidden layer.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Constructor)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Hidden<const N: usize> {
     #[cfg_attr(test, map(|b: i8| i32::from(b)))]

--- a/lib/nnue/transformer.rs
+++ b/lib/nnue/transformer.rs
@@ -1,6 +1,5 @@
 use crate::nnue::Feature;
 use crate::util::{AlignTo64, Assume, Integer};
-use derive_more::Constructor;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 #[cfg(test)]
@@ -10,7 +9,7 @@ use proptest::{prelude::*, sample::Index};
 use std::ops::Range;
 
 /// A feature transformer.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Constructor)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Transformer<T, const N: usize> {
     pub(super) bias: AlignTo64<[T; N]>,
     pub(super) weight: AlignTo64<[[T; N]; Feature::LEN]>,

--- a/lib/search/driver.rs
+++ b/lib/search/driver.rs
@@ -20,6 +20,7 @@ pub enum Driver {
 
 impl Driver {
     /// Constructs a parallel search driver with the given [`ThreadCount`].
+    #[inline(always)]
     pub fn new(threads: ThreadCount) -> Self {
         match threads.get() {
             1 => Self::Sequential,

--- a/lib/search/limits.rs
+++ b/lib/search/limits.rs
@@ -25,6 +25,7 @@ pub enum Limits {
 
 impl Limits {
     /// Maximum depth or [`Depth::MAX`].
+    #[inline(always)]
     pub fn depth(&self) -> Depth {
         match self {
             Limits::Depth(d) => *d,
@@ -33,6 +34,7 @@ impl Limits {
     }
 
     /// Maximum number of nodes [`u64::MAX`].
+    #[inline(always)]
     pub fn nodes(&self) -> u64 {
         match self {
             Limits::Nodes(n) => *n,
@@ -41,6 +43,7 @@ impl Limits {
     }
 
     /// Maximum time or [`Duration::MAX`].
+    #[inline(always)]
     pub fn time(&self) -> Duration {
         match self {
             Limits::Time(t) => *t,
@@ -50,6 +53,7 @@ impl Limits {
     }
 
     /// Time left on the clock or [`Duration::MAX`].
+    #[inline(always)]
     pub fn clock(&self) -> Duration {
         match self {
             Limits::Clock(t, _) => *t,
@@ -58,6 +62,7 @@ impl Limits {
     }
 
     /// Time increment or [`Duration::ZERO`].
+    #[inline(always)]
     pub fn increment(&self) -> Duration {
         match self {
             Limits::Clock(_, i) => *i,

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -52,6 +52,7 @@ pub struct Transposition {
 }
 
 impl Transposition {
+    #[inline(always)]
     fn new(kind: TranspositionKind, depth: Depth, score: Score, best: Move) -> Self {
         Transposition {
             kind,
@@ -62,21 +63,25 @@ impl Transposition {
     }
 
     /// Constructs a [`Transposition`] given a lower bound for the score, the depth searched, and best [`Move`].
+    #[inline(always)]
     pub fn lower(depth: Depth, score: Score, best: Move) -> Self {
         Transposition::new(TranspositionKind::Lower, depth, score, best)
     }
 
     /// Constructs a [`Transposition`] given an upper bound for the score, the depth searched, and best [`Move`].
+    #[inline(always)]
     pub fn upper(depth: Depth, score: Score, best: Move) -> Self {
         Transposition::new(TranspositionKind::Upper, depth, score, best)
     }
 
     /// Constructs a [`Transposition`] given the exact score, the depth searched, and best [`Move`].
+    #[inline(always)]
     pub fn exact(depth: Depth, score: Score, best: Move) -> Self {
         Transposition::new(TranspositionKind::Exact, depth, score, best)
     }
 
     /// Bounds for the exact score.
+    #[inline(always)]
     pub fn bounds(&self) -> RangeInclusive<Score> {
         match self.kind {
             TranspositionKind::Lower => self.score..=Score::upper(),
@@ -86,16 +91,19 @@ impl Transposition {
     }
 
     /// Depth searched.
+    #[inline(always)]
     pub fn depth(&self) -> Depth {
         self.depth
     }
 
     /// Partial score.
+    #[inline(always)]
     pub fn score(&self) -> Score {
         self.score
     }
 
     /// Best [`Move`] at this depth.
+    #[inline(always)]
     pub fn best(&self) -> Move {
         self.best
     }
@@ -174,6 +182,7 @@ impl TranspositionTable {
     const WIDTH: usize = size_of::<<Option<SignedTransposition> as Binary>::Bits>();
 
     /// Constructs a transposition table of at most `size` many bytes.
+    #[inline(always)]
     pub fn new(size: HashSize) -> Self {
         let capacity = (1 + size.get() / 2).next_power_of_two() / Self::WIDTH;
 
@@ -183,11 +192,13 @@ impl TranspositionTable {
     }
 
     /// The actual size of this table in bytes.
+    #[inline(always)]
     pub fn size(&self) -> HashSize {
         HashSize::new(self.capacity() * Self::WIDTH)
     }
 
     /// The actual size of this table in number of entries.
+    #[inline(always)]
     pub fn capacity(&self) -> usize {
         self.cache.len()
     }

--- a/lib/util/integer.rs
+++ b/lib/util/integer.rs
@@ -1,4 +1,4 @@
-use std::num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+use std::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 use std::{mem::transmute_copy, ops::*};
 
 /// Trait for types that can be represented by a contiguous range of primitive integers.
@@ -133,6 +133,7 @@ impl_integer_for_non_zero!(NonZeroU8, u8);
 impl_integer_for_non_zero!(NonZeroU16, u16);
 impl_integer_for_non_zero!(NonZeroU32, u32);
 impl_integer_for_non_zero!(NonZeroU64, u64);
+impl_integer_for_non_zero!(NonZeroU128, u128);
 impl_integer_for_non_zero!(NonZeroUsize, usize);
 
 macro_rules! impl_primitive_for {


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 7 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -15       5    9000    2168    2569    4263   4299.5   47.8%   47.4% 
   1 Frozenight-6.0                 23       9    3000     912     711    1377   1600.5   53.3%   45.9% 
   2 Marvin-6.2                     17       9    3000     810     663    1527   1573.5   52.4%   50.9% 
   3 Halogen-11.0                    6       9    3000     847     794    1359   1526.5   50.9%   45.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     57     64     71     66     56     61     56     49     63     52     55     59     58     48    883
   Score   7738   7024   7535   8145   7838   7642   7421   6905   6149   7432   6363   6967   6689   6963   6485 107296
Score(%)   91.0   87.8   87.6   91.5   92.2   95.5   90.5   86.3   86.6   94.1   90.9   94.1   89.2   88.1   88.8   90.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.5%, "Re-Capturing"
2. STS 12, 94.1%, "Center Control"
3. STS 10, 94.1%, "Simplification"
4. STS 05, 92.2%, "Bishop vs Knight"
5. STS 04, 91.5%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 08, 86.3%, "Advancement of f/g/h Pawns"
2. STS 09, 86.6%, "Advancement of a/b/c Pawns"
3. STS 03, 87.6%, "Knight Outposts"
4. STS 02, 87.8%, "Open Files and Diagonals"
5. STS 14, 88.1%, "Queens and Rooks to the 7th rank"
```