### PR TITLE
Slightly tune down the line of sight of threefold repetitions to 32 moves

### DIFF
--- a/lib/chess/position.rs
+++ b/lib/chess/position.rs
@@ -168,7 +168,7 @@ pub struct Position {
     zobrist: Zobrist,
     checkers: Bitboard,
     pinned: Bitboard,
-    history: [[Option<NonZeroU16>; 48]; 2],
+    history: [[Option<NonZeroU16>; 32]; 2],
 }
 
 impl Default for Position {
@@ -180,7 +180,7 @@ impl Default for Position {
             zobrist: board.zobrist(),
             checkers: Default::default(),
             pinned: Default::default(),
-            history: [[None; 48]; 2],
+            history: Default::default(),
             board,
         }
     }
@@ -499,7 +499,7 @@ impl Position {
 
         if role == Pawn || capture.is_some() {
             self.board.halfmoves = 0;
-            self.history = [[None; 48]; 2];
+            self.history = Default::default();
         } else {
             self.board.halfmoves += 1;
             let entries = self.history[turn as usize].len();
@@ -669,7 +669,7 @@ impl FromStr for Position {
             checkers,
             pinned,
             zobrist: board.zobrist(),
-            history: [[None; 48]; 2],
+            history: Default::default(),
             board,
         })
     }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 8 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Frozenight-6.0 -engine conf=Halogen-11.0 -engine conf=Marvin-6.2 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -3       5    9000    2469    2553    3978   4458.0   49.5%   44.2% 
   1 Frozenight-6.0                 12       9    3000     901     801    1298   1550.0   51.7%   43.3% 
   2 Marvin-6.2                      0       9    3000     765     763    1472   1501.0   50.0%   49.1% 
   3 Halogen-11.0                   -2      10    3000     887     905    1208   1491.0   49.7%   40.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     63     58     65     72     72     54     53     49     46     65     55     56     62     59     49    878
   Score   7564   7065   7731   8373   8143   7630   7143   6671   5924   7439   6510   6705   7015   7243   6609 107765
Score(%)   89.0   88.3   89.9   94.1   95.8   95.4   87.1   83.4   83.4   94.2   93.0   90.6   93.5   91.7   90.5   90.7

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 95.8%, "Bishop vs Knight"
2. STS 06, 95.4%, "Re-Capturing"
3. STS 10, 94.2%, "Simplification"
4. STS 04, 94.1%, "Square Vacancy"
5. STS 13, 93.5%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 08, 83.4%, "Advancement of f/g/h Pawns"
2. STS 09, 83.4%, "Advancement of a/b/c Pawns"
3. STS 07, 87.1%, "Offer of Simplification"
4. STS 02, 88.3%, "Open Files and Diagonals"
5. STS 01, 89.0%, "Undermining"

```