### PR TITLE
Do not reduce or extend at the root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 keywords = ["chess"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(coverage)',
+    'cfg(feature, values("used_linker"))',
+] }
 
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false, features = ["std"] }

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -1,34 +1,24 @@
 use crate::{chess::Move, search::Score};
+use derive_more::{Constructor, Deref};
 use std::cmp::Ordering;
 use std::ops::{Neg, Shr};
 
 /// The [principal variation].
 ///
 /// [principal variation]: https://www.chessprogramming.org/Principal_Variation
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Constructor, Deref)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Pv {
     score: Score,
-    best: Option<Move>,
+    #[deref]
+    r#move: Option<Move>,
 }
 
 impl Pv {
-    /// Constructs a pv.
-    #[inline(always)]
-    pub fn new(score: Score, best: Option<Move>) -> Self {
-        Pv { score, best }
-    }
-
     /// The score from the point of view of the side to move.
     #[inline(always)]
     pub fn score(&self) -> Score {
         self.score
-    }
-
-    /// An iterator over [`Move`]s in this principal variation.
-    #[inline(always)]
-    pub fn best(&self) -> Option<Move> {
-        self.best
     }
 }
 
@@ -81,7 +71,7 @@ impl Shr<Pv> for Move {
 
     #[inline(always)]
     fn shr(self, mut pv: Pv) -> Self::Output {
-        pv.best = Some(self);
+        pv.r#move = Some(self);
         pv
     }
 }
@@ -103,12 +93,12 @@ mod tests {
 
     #[proptest]
     fn negation_preserves_best(pv: Pv) {
-        assert_eq!(pv.neg().best(), pv.best());
+        assert_eq!(*pv.neg(), *pv);
     }
 
     #[proptest]
     fn shift_changes_best(pv: Pv, m: Move) {
-        assert_eq!(m.shr(pv).best(), Some(m));
+        assert_eq!(*m.shr(pv), Some(m));
     }
 
     #[proptest]

--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -1,5 +1,5 @@
 use crate::chess::{Move, Zobrist};
-use crate::search::{Depth, HashSize, Score};
+use crate::search::{Depth, HashSize, Ply, Pv, Score};
 use crate::util::{Assume, Binary, Bits, Integer};
 use derive_more::Debug;
 use std::mem::size_of;
@@ -102,10 +102,10 @@ impl Transposition {
         self.score
     }
 
-    /// Best [`Move`] at this depth.
+    /// Principal variation normalized to [`Ply`].
     #[inline(always)]
-    pub fn best(&self) -> Move {
-        self.best
+    pub fn pv(&self, ply: Ply) -> Pv {
+        Pv::new(self.score().normalize(ply), Some(self.best))
     }
 }
 

--- a/lib/uci.rs
+++ b/lib/uci.rs
@@ -98,7 +98,7 @@ impl<I: FusedStream<Item = String> + Unpin, O: Sink<String> + Unpin> Uci<I, O> {
 
         self.output.send(info).await?;
 
-        if let Some(m) = pv.best() {
+        if let Some(m) = *pv {
             self.output.send(format!("bestmove {m}")).await?;
         }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 8 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Carp-3.0.1 -engine conf=Winter-4.0 -engine conf=Frozenight-6.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -3       5    9000    2536    2603    3861   4466.5   49.6%   42.9% 
   1 Carp-3.0.1                     17      10    3000     973     823    1204   1575.0   52.5%   40.1% 
   2 Winter-4.0                      7       9    3000     856     793    1351   1531.5   51.0%   45.0% 
   3 Frozenight-6.0                -17       9    3000     774     920    1306   1427.0   47.6%   43.5%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     60     66     72     68     56     55     56     44     67     53     51     59     61     47    887
   Score   7971   6925   7842   8419   7934   7564   7294   7007   5931   7491   6414   6401   6855   7144   6483 107675
Score(%)   93.8   86.6   91.2   94.6   93.3   94.5   89.0   87.6   83.5   94.8   91.6   86.5   91.4   90.4   88.8   90.6

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 10, 94.8%, "Simplification"
2. STS 04, 94.6%, "Square Vacancy"
3. STS 06, 94.5%, "Re-Capturing"
4. STS 01, 93.8%, "Undermining"
5. STS 05, 93.3%, "Bishop vs Knight"

:: Top 5 STS with low result ::
1. STS 09, 83.5%, "Advancement of a/b/c Pawns"
2. STS 12, 86.5%, "Center Control"
3. STS 02, 86.6%, "Open Files and Diagonals"
4. STS 08, 87.6%, "Advancement of f/g/h Pawns"
5. STS 15, 88.8%, "Avoid Pointless Exchange"
```