### PR TITLE
Disable reverse futility pruning at PV nodes

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -189,7 +189,7 @@ impl Engine {
 
         if alpha >= beta || ply >= Ply::MAX {
             return Ok(pv);
-        } else if pv.score() - self.rfp(depth, ply) >= beta {
+        } else if !is_pv && pv.score() - self.rfp(depth, ply) >= beta {
             #[cfg(not(test))]
             // The reverse futility pruning heuristic is not exact.
             return Ok(pv);


### PR DESCRIPTION

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 8 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Carp-3.0.1 -engine conf=Winter-4.0 -engine conf=Frozenight-6.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw
   0 dev                            -2       5    9000    2546    2591    3863   4477.5   49.8%   42.9%
   1 Carp-3.0.1                     23      10    3000     988     791    1221   1598.5   53.3%   40.7%
   2 Winter-4.0                      3       9    3000     843     817    1340   1513.0   50.4%   44.7%
   3 Frozenight-6.0                -21       9    3000     760     938    1302   1411.0   47.0%   43.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     66     60     67     70     66     56     63     56     50     62     48     52     58     61     51    886
   Score   7633   7160   7808   8267   7887   7614   7468   6930   6326   7302   6247   6698   6686   7236   6732 107994
Score(%)   89.8   89.5   90.8   92.9   92.8   95.2   91.1   86.6   89.1   92.4   89.2   90.5   89.1   91.6   92.2   90.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.2%, "Re-Capturing"
2. STS 04, 92.9%, "Square Vacancy"
3. STS 05, 92.8%, "Bishop vs Knight"
4. STS 10, 92.4%, "Simplification"
5. STS 15, 92.2%, "Avoid Pointless Exchange"

:: Top 5 STS with low result ::
1. STS 08, 86.6%, "Advancement of f/g/h Pawns"
2. STS 09, 89.1%, "Advancement of a/b/c Pawns"
3. STS 13, 89.1%, "Pawn Play in the Center"
4. STS 11, 89.2%, "Activity of the King"
5. STS 02, 89.5%, "Open Files and Diagonals"
```