### PR TITLE
Implement multi-cut pruning with singular extension

### DIFF
--- a/lib/search/transposition.rs
+++ b/lib/search/transposition.rs
@@ -46,17 +46,17 @@ impl Binary for TranspositionKind {
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct Transposition {
     kind: TranspositionKind,
-    depth: Depth,
+    draft: Depth,
     score: Score,
     best: Move,
 }
 
 impl Transposition {
     #[inline(always)]
-    fn new(kind: TranspositionKind, depth: Depth, score: Score, best: Move) -> Self {
+    fn new(kind: TranspositionKind, draft: Depth, score: Score, best: Move) -> Self {
         Transposition {
             kind,
-            depth,
+            draft,
             score,
             best,
         }
@@ -64,20 +64,20 @@ impl Transposition {
 
     /// Constructs a [`Transposition`] given a lower bound for the score, the depth searched, and best [`Move`].
     #[inline(always)]
-    pub fn lower(depth: Depth, score: Score, best: Move) -> Self {
-        Transposition::new(TranspositionKind::Lower, depth, score, best)
+    pub fn lower(draft: Depth, score: Score, best: Move) -> Self {
+        Transposition::new(TranspositionKind::Lower, draft, score, best)
     }
 
     /// Constructs a [`Transposition`] given an upper bound for the score, the depth searched, and best [`Move`].
     #[inline(always)]
-    pub fn upper(depth: Depth, score: Score, best: Move) -> Self {
-        Transposition::new(TranspositionKind::Upper, depth, score, best)
+    pub fn upper(draft: Depth, score: Score, best: Move) -> Self {
+        Transposition::new(TranspositionKind::Upper, draft, score, best)
     }
 
     /// Constructs a [`Transposition`] given the exact score, the depth searched, and best [`Move`].
     #[inline(always)]
-    pub fn exact(depth: Depth, score: Score, best: Move) -> Self {
-        Transposition::new(TranspositionKind::Exact, depth, score, best)
+    pub fn exact(draft: Depth, score: Score, best: Move) -> Self {
+        Transposition::new(TranspositionKind::Exact, draft, score, best)
     }
 
     /// Bounds for the exact score.
@@ -92,8 +92,8 @@ impl Transposition {
 
     /// Depth searched.
     #[inline(always)]
-    pub fn depth(&self) -> Depth {
-        self.depth
+    pub fn draft(&self) -> Depth {
+        self.draft
     }
 
     /// Partial score.
@@ -115,7 +115,7 @@ impl Binary for Transposition {
     #[inline(always)]
     fn encode(&self) -> Self::Bits {
         let mut bits = Bits::default();
-        bits.push(self.depth.encode());
+        bits.push(self.draft.encode());
         bits.push(self.kind.encode());
         bits.push(self.score.encode());
         bits.push(self.best.encode());
@@ -128,7 +128,7 @@ impl Binary for Transposition {
             best: Binary::decode(bits.pop()),
             score: Binary::decode(bits.pop()),
             kind: Binary::decode(bits.pop()),
-            depth: Binary::decode(bits.pop()),
+            draft: Binary::decode(bits.pop()),
         }
     }
 }
@@ -231,8 +231,6 @@ impl TranspositionTable {
     }
 
     /// Stores a [`Transposition`] in the slot associated with `key`.
-    ///
-    /// In the slot if not empty, the [`Transposition`] with greater depth is chosen.
     #[inline(always)]
     pub fn set(&self, key: Zobrist, tpos: Transposition) {
         if self.capacity() > 0 {


### PR DESCRIPTION
### SPRT

> `cutechess-cli -sprt elo0=0 elo1=5 alpha=0.05 beta=0.05 -games 2 -rounds 4000 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=base -each tc=3+0.025`

```
Score of dev vs base: 317 - 215 - 620  [0.544] 1152
...      dev playing White: 210 - 66 - 301  [0.625] 577
...      dev playing Black: 107 - 149 - 319  [0.463] 575
...      White vs Black: 359 - 173 - 620  [0.581] 1152
Elo difference: 30.8 +/- 13.6, LOS: 100.0 %, DrawRatio: 53.8 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```

### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Carp-3.0.1 -engine conf=Winter-4.0 -engine conf=Frozenight-6.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            29       5    9000    3008    2262    3730   4873.0   54.1%   41.4% 
   1 Carp-3.0.1                     -8      10    3000     881     948    1171   1466.5   48.9%   39.0% 
   2 Frozenight-6.0                -39       9    3000     699    1031    1270   1334.0   44.5%   42.3% 
   3 Winter-4.0                    -40       9    3000     682    1029    1289   1326.5   44.2%   43.0%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     67     56     61     69     70     57     57     55     46     62     54     51     64     63     47    879
   Score   7716   6836   7666   8259   7926   7621   7281   7001   5998   7264   6518   6613   7025   7295   6486 107505
Score(%)   90.8   85.5   89.1   92.8   93.2   95.3   88.8   87.5   84.5   91.9   93.1   89.4   93.7   92.3   88.8   90.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.3%, "Re-Capturing"
2. STS 13, 93.7%, "Pawn Play in the Center"
3. STS 05, 93.2%, "Bishop vs Knight"
4. STS 11, 93.1%, "Activity of the King"
5. STS 04, 92.8%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 09, 84.5%, "Advancement of a/b/c Pawns"
2. STS 02, 85.5%, "Open Files and Diagonals"
3. STS 08, 87.5%, "Advancement of f/g/h Pawns"
4. STS 07, 88.8%, "Offer of Simplification"
5. STS 15, 88.8%, "Avoid Pointless Exchange"
```