### PR TITLE
Enable multi-cut pruning with singular extension when in check

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -280,7 +280,7 @@ impl Engine {
 
         if let Some(t) = transposition {
             if let Some(d) = self.mcp(*t.bounds().start() - beta, draft) {
-                if !is_root && !pos.is_check() && t.draft() >= d {
+                if !is_root && t.draft() >= d {
                     for (m, _) in moves.iter().rev().skip(1) {
                         let mut next = pos.clone();
                         next.play(*m);


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Carp-3.0.1 -engine conf=Winter-4.0 -engine conf=Frozenight-6.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            35       6    9000    3138    2235    3627   4951.5   55.0%   40.3% 
   1 Carp-3.0.1                    -26      10    3000     836    1064    1100   1386.0   46.2%   36.7% 
   2 Winter-4.0                    -38       9    3000     694    1025    1281   1334.5   44.5%   42.7% 
   3 Frozenight-6.0                -40      10    3000     705    1049    1246   1328.0   44.3%   41.5% 
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     71     56     60     69     70     53     56     55     46     63     53     57     60     63     49    881
   Score   7881   6941   7471   8142   8002   7554   7237   6830   6033   7403   6454   6808   6873   7169   6575 107373
Score(%)   92.7   86.8   86.9   91.5   94.1   94.4   88.3   85.4   85.0   93.7   92.2   92.0   91.6   90.7   90.1   90.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.4%, "Re-Capturing"
2. STS 05, 94.1%, "Bishop vs Knight"
3. STS 10, 93.7%, "Simplification"
4. STS 01, 92.7%, "Undermining"
5. STS 11, 92.2%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 09, 85.0%, "Advancement of a/b/c Pawns"
2. STS 08, 85.4%, "Advancement of f/g/h Pawns"
3. STS 02, 86.8%, "Open Files and Diagonals"
4. STS 03, 86.9%, "Knight Outposts"
5. STS 07, 88.3%, "Offer of Simplification"
```