### PR TITLE
Increase internal iterative reductions

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -37,7 +37,7 @@ fn crit(c: &mut Criterion) {
     }));
 
     for o in &options {
-        let depth = Depth::new(14);
+        let depth = Depth::new(16);
         c.benchmark_group("ttd")
             .sampling_mode(SamplingMode::Flat)
             .bench_function(o.threads.to_string(), |b| {
@@ -46,7 +46,7 @@ fn crit(c: &mut Criterion) {
     }
 
     for o in &options {
-        let nodes = 500_000;
+        let nodes = 200_000;
         c.benchmark_group("nps")
             .sampling_mode(SamplingMode::Flat)
             .throughput(Throughput::Elements(nodes))

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -203,7 +203,7 @@ impl Engine {
             #[cfg(not(test))]
             if transposition.is_none() && !pos.is_check() {
                 // The internal iterative reduction heuristic is not exact.
-                depth = depth - 1;
+                depth = depth - 2;
             }
         }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -43       6    9000    2127    3232    3641   3947.5   43.9%   40.5% 
   1 Halogen-12.0                   58      10    3000    1149     650    1201   1749.5   58.3%   40.0% 
   2 Willow-4.0                     40      10    3000    1087     745    1168   1671.0   55.7%   38.9% 
   3 Pawn-3.0                       31       9    3000     996     732    1272   1632.0   54.4%   42.4% 
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     72     53     65     72     70     58     60     53     50     63     52     52     62     61     46    889
   Score   8015   6850   7642   8268   8004   7658   7303   6877   6171   7354   6478   6698   6850   7227   6542 107937
Score(%)   94.3   85.6   88.9   92.9   94.2   95.7   89.1   86.0   86.9   93.1   92.5   90.5   91.3   91.5   89.6   90.9

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.7%, "Re-Capturing"
2. STS 01, 94.3%, "Undermining"
3. STS 05, 94.2%, "Bishop vs Knight"
4. STS 10, 93.1%, "Simplification"
5. STS 04, 92.9%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 02, 85.6%, "Open Files and Diagonals"
2. STS 08, 86.0%, "Advancement of f/g/h Pawns"
3. STS 09, 86.9%, "Advancement of a/b/c Pawns"
4. STS 03, 88.9%, "Knight Outposts"
5. STS 07, 89.1%, "Offer of Simplification"
```