### PR TITLE
Share killer moves across all threads

### DIFF
--- a/lib/search/killers.rs
+++ b/lib/search/killers.rs
@@ -1,45 +1,78 @@
 use crate::chess::{Color, Move};
-use crate::{search::Ply, util::Integer};
+use crate::search::Ply;
+use crate::util::{Assume, Binary, Bits, Integer};
+use std::sync::atomic::AtomicU32;
+use std::{array, sync::atomic::Ordering::Relaxed};
+
+/// A pair of [killer moves].
+///
+/// [killer moves]: https://www.chessprogramming.org/Killer_Move
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct Killer(Option<Move>, Option<Move>);
+
+impl Killer {
+    /// Adds a killer move to the pair.
+    #[inline(always)]
+    pub fn insert(&mut self, m: Move) {
+        if self.0 != Some(m) {
+            self.1 = self.0;
+            self.0 = Some(m);
+        }
+    }
+
+    /// Whether a move is a killer.
+    #[inline(always)]
+    pub fn contains(&self, m: Move) -> bool {
+        self.0 == Some(m) || self.1 == Some(m)
+    }
+}
+
+impl Binary for Killer {
+    type Bits = Bits<u32, 32>;
+
+    #[inline(always)]
+    fn encode(&self) -> Self::Bits {
+        let mut bits = Bits::default();
+        bits.push(self.1.encode());
+        bits.push(self.0.encode());
+        bits
+    }
+
+    #[inline(always)]
+    fn decode(mut bits: Self::Bits) -> Self {
+        Killer(Binary::decode(bits.pop()), Binary::decode(bits.pop()))
+    }
+}
 
 /// A set of [killer moves] indexed by [`Ply`] and side to move.
 ///
 /// [killer moves]: https://www.chessprogramming.org/Killer_Move
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct Killers<const P: usize>([[[Option<Move>; 2]; 2]; P]);
+#[derive(Debug)]
+pub struct Killers([[AtomicU32; 2]; Ply::MAX as usize]);
 
-impl<const P: usize> Default for Killers<P> {
+impl Default for Killers {
     #[inline(always)]
     fn default() -> Self {
-        Self::new()
+        Killers(array::from_fn(|_| [AtomicU32::new(0), AtomicU32::new(0)]))
     }
 }
 
-impl<const P: usize> Killers<P> {
-    /// Constructs an empty set of killer moves.
-    #[inline(always)]
-    pub const fn new() -> Self {
-        Killers([[[None; 2]; 2]; P])
-    }
-
+impl Killers {
     /// Adds a killer move to the set at a given ply for a given side to move.
     #[inline(always)]
-    pub fn insert(&mut self, ply: Ply, side: Color, m: Move) {
-        if let Some(ks) = self.0.get_mut(ply.cast::<usize>()) {
-            let [first, last] = &mut ks[side as usize];
-            if *first != Some(m) {
-                *last = *first;
-                *first = Some(m);
-            }
-        }
+    pub fn insert(&self, ply: Ply, side: Color, m: Move) {
+        let slot = &self.0.get(ply.cast::<usize>()).assume()[side.cast::<usize>()];
+        let mut killer = Killer::decode(Bits::new(slot.load(Relaxed)));
+        killer.insert(m);
+        slot.store(killer.encode().get(), Relaxed);
     }
 
-    /// Checks whether move is a known killer at a given ply for a given side to move.
+    /// Returns the known killer moves at a given ply for a given side to move.
     #[inline(always)]
-    pub fn contains(&self, ply: Ply, side: Color, m: Move) -> bool {
-        self.0
-            .get(ply.cast::<usize>())
-            .is_some_and(|ks| ks[side as usize].contains(&Some(m)))
+    pub fn get(&self, ply: Ply, side: Color) -> Killer {
+        let slot = &self.0.get(ply.cast::<usize>()).assume()[side.cast::<usize>()];
+        Killer::decode(Bits::new(slot.load(Relaxed)))
     }
 }
 
@@ -52,59 +85,49 @@ mod tests {
     use test_strategy::proptest;
 
     #[proptest]
-    fn insert_avoids_duplicated_moves(#[filter(#p >= 0)] p: Ply, c: Color, m: Move) {
-        let mut ks = Killers::<{ Ply::MAX as usize + 1 }>::new();
-
-        ks.insert(p, c, m);
-        ks.insert(p, c, m);
-
-        assert_eq!(ks.0[p.get() as usize][c as usize], [Some(m), None]);
+    fn decoding_encoded_killer(k: Killer) {
+        assert_eq!(Killer::decode(k.encode()), k);
     }
 
     #[proptest]
-    fn insert_keeps_most_recent(
-        #[filter(#p >= 0)] p: Ply,
-        c: Color,
-        #[any(size_range(2..10).lift())] ms: HashSet<Move>,
-        m: Move,
-    ) {
-        let mut ks = Killers::<{ Ply::MAX as usize + 1 }>::new();
+    fn contains_returns_true_only_if_inserted(m: Move) {
+        let mut k = Killer::default();
+        assert!(!k.contains(m));
+        k.insert(m);
+        assert!(k.contains(m));
+    }
+
+    #[proptest]
+    fn insert_avoids_duplicated_moves(m: Move) {
+        let mut k = Killer::default();
+
+        k.insert(m);
+        k.insert(m);
+
+        assert_eq!(k, Killer(Some(m), None));
+    }
+
+    #[proptest]
+    fn insert_keeps_most_recent(#[any(size_range(2..10).lift())] ms: HashSet<Move>, m: Move) {
+        let mut k = Killer::default();
 
         for m in ms {
-            ks.insert(p, c, m);
+            k.insert(m);
         }
 
-        ks.insert(p, c, m);
-        assert_eq!(ks.0[p.get() as usize][c as usize][0], Some(m));
+        k.insert(m);
+        assert_eq!(k.0, Some(m));
     }
 
     #[proptest]
-    fn insert_ignores_ply_out_of_bounds(
-        mut ks: Killers<1>,
-        #[filter(#p > 0)] p: Ply,
+    fn get_turns_killers_at_ply_for_the_side_to_move(
+        #[filter((0..Ply::MAX).contains(&#p.get()))] p: Ply,
         c: Color,
         m: Move,
     ) {
-        let prev = ks.clone();
+        let ks = Killers::default();
         ks.insert(p, c, m);
-        assert_eq!(ks, prev);
-    }
-
-    #[proptest]
-    fn contains_returns_true_only_if_inserted(#[filter(#p >= 0)] p: Ply, c: Color, m: Move) {
-        let mut ks = Killers::<{ Ply::MAX as usize + 1 }>::new();
-        assert!(!ks.contains(p, c, m));
-        ks.insert(p, c, m);
-        assert!(ks.contains(p, c, m));
-    }
-
-    #[proptest]
-    fn contains_returns_false_if_ply_out_of_bounds(
-        ks: Killers<1>,
-        #[filter(#p > 0)] p: Ply,
-        c: Color,
-        m: Move,
-    ) {
-        assert!(!ks.contains(p, c, m));
+        let k = ks.get(p, c);
+        assert_eq!(k.0, Some(m));
     }
 }

--- a/lib/util/trigger.rs
+++ b/lib/util/trigger.rs
@@ -7,13 +7,13 @@ pub struct Trigger(AtomicBool);
 impl Trigger {
     /// An armed trigger.
     #[inline(always)]
-    pub const fn armed() -> Self {
+    pub fn armed() -> Self {
         Trigger(AtomicBool::new(true))
     }
 
     /// A disarmed trigger.
     #[inline(always)]
-    pub const fn disarmed() -> Self {
+    pub fn disarmed() -> Self {
         Trigger(AtomicBool::new(false))
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                           -40       5    9000    2114    3142    3744   3986.0   44.3%   41.6% 
   1 Halogen-12.0                   64      10    3000    1146     596    1258   1775.0   59.2%   41.9% 
   2 Pawn-3.0                       33       9    3000     988     706    1306   1641.0   54.7%   43.5% 
   3 Willow-4.0                     23      10    3000    1008     812    1180   1598.0   53.3%   39.3%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     68     56     63     68     71     55     57     59     49     61     53     56     60     57     50    883
   Score   7755   6893   7574   8209   7960   7663   7320   7119   6197   7234   6314   6836   6871   6928   6629 107502
Score(%)   91.2   86.2   88.1   92.2   93.6   95.8   89.3   89.0   87.3   91.6   90.2   92.4   91.6   87.7   90.8   90.5

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 95.8%, "Re-Capturing"
2. STS 05, 93.6%, "Bishop vs Knight"
3. STS 12, 92.4%, "Center Control"
4. STS 04, 92.2%, "Square Vacancy"
5. STS 13, 91.6%, "Pawn Play in the Center"

:: Top 5 STS with low result ::
1. STS 02, 86.2%, "Open Files and Diagonals"
2. STS 09, 87.3%, "Advancement of a/b/c Pawns"
3. STS 14, 87.7%, "Queens and Rooks to the 7th rank"
4. STS 03, 88.1%, "Knight Outposts"
5. STS 08, 89.0%, "Advancement of f/g/h Pawns"
```