### PR TITLE
Tweak reverse futility pruning margins

### DIFF
--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -98,8 +98,8 @@ impl Engine {
     fn rfp(&self, surplus: Score, draft: Depth) -> Option<Depth> {
         match surplus.get() {
             ..0 => None,
-            0..600 => Some(draft - surplus / 100),
-            600.. => Some(draft - 6),
+            0..680 => Some(draft - (surplus + 40) / 120),
+            680.. => Some(draft - 6),
         }
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -5       5    9000    2486    2613    3901   4436.5   49.3%   43.3% 
   1 Halogen-12.0                   26       9    3000     975     748    1277   1613.5   53.8%   42.6% 
   2 Pawn-3.0                       -4       9    3000     781     814    1405   1483.5   49.5%   46.8% 
   3 Willow-4.0                     -8      10    3000     857     924    1219   1466.5   48.9%   40.6%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     70     61     66     71     69     58     60     56     50     62     53     58     62     63     51    910
   Score   7912   7002   7739   8387   7870   7691   7307   6905   6320   7318   6375   6825   6911   7361   6676 108599
Score(%)   93.1   87.5   90.0   94.2   92.6   96.1   89.1   86.3   89.0   92.6   91.1   92.2   92.1   93.2   91.5   91.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.1%, "Re-Capturing"
2. STS 04, 94.2%, "Square Vacancy"
3. STS 14, 93.2%, "Queens and Rooks to the 7th rank"
4. STS 01, 93.1%, "Undermining"
5. STS 10, 92.6%, "Simplification"

:: Top 5 STS with low result ::
1. STS 08, 86.3%, "Advancement of f/g/h Pawns"
2. STS 02, 87.5%, "Open Files and Diagonals"
3. STS 09, 89.0%, "Advancement of a/b/c Pawns"
4. STS 07, 89.1%, "Offer of Simplification"
5. STS 03, 90.0%, "Knight Outposts"
```