### PR TITLE
Implement trait Assume for bool

### DIFF
--- a/lib/chess/move.rs
+++ b/lib/chess/move.rs
@@ -279,16 +279,6 @@ mod tests {
     }
 
     #[proptest]
-    #[should_panic]
-    fn constructing_capture_move_panics_with_invalid_promotion(
-        wc: Square,
-        #[filter(#wc != #wt)] wt: Square,
-        #[strategy(select(&[Role::Pawn, Role::King]))] p: Role,
-    ) {
-        Move::capture(wc, wt, Some(p));
-    }
-
-    #[proptest]
     fn quiet_move_can_be_constructed(wc: Square, #[filter(#wc != #wt)] wt: Square) {
         assert!(Move::regular(wc, wt, None).is_quiet());
     }
@@ -300,16 +290,6 @@ mod tests {
         #[strategy(select(&[Role::Knight, Role::Bishop, Role::Rook, Role::Queen]))] p: Role,
     ) {
         assert!(Move::regular(wc, wt, Some(p)).is_promotion());
-    }
-
-    #[proptest]
-    #[should_panic]
-    fn constructing_promotion_move_panics_with_invalid_promotion(
-        wc: Square,
-        #[filter(#wc != #wt)] wt: Square,
-        #[strategy(select(&[Role::Pawn, Role::King]))] p: Role,
-    ) {
-        Move::regular(wc, wt, Some(p));
     }
 
     #[proptest]

--- a/lib/nnue/hidden.rs
+++ b/lib/nnue/hidden.rs
@@ -1,4 +1,4 @@
-use crate::util::AlignTo64;
+use crate::util::{AlignTo64, Assume};
 use std::ops::Shl;
 
 /// The hidden layer.
@@ -44,8 +44,8 @@ impl<const N: usize> Hidden<N> {
         let mut y = _mm256_setr_epi32(self.bias, 0, 0, 0, 0, 0, 0, 0);
 
         for (w, i) in self.weight.iter().zip([us, them]) {
-            debug_assert_eq!(w.as_ptr() as usize % 32, 0);
-            debug_assert_eq!(i.as_ptr() as usize % 32, 0);
+            (w.as_ptr() as usize % 32 == 0).assume();
+            (i.as_ptr() as usize % 32 == 0).assume();
 
             for (a, x) in Iterator::zip(w.array_chunks::<128>(), i.array_chunks::<128>()) {
                 let a = transmute::<&[i8; 128], &[__m256i; 4]>(a);
@@ -101,8 +101,8 @@ impl<const N: usize> Hidden<N> {
         let mut y = _mm_setr_epi32(self.bias, 0, 0, 0);
 
         for (w, i) in self.weight.iter().zip([us, them]) {
-            debug_assert_eq!(w.as_ptr() as usize % 16, 0);
-            debug_assert_eq!(i.as_ptr() as usize % 16, 0);
+            (w.as_ptr() as usize % 16 == 0).assume();
+            (i.as_ptr() as usize % 16 == 0).assume();
 
             for (a, x) in Iterator::zip(w.array_chunks::<64>(), i.array_chunks::<64>()) {
                 let a = transmute::<&[i8; 64], &[__m128i; 4]>(a);

--- a/lib/search/options.rs
+++ b/lib/search/options.rs
@@ -152,12 +152,6 @@ mod tests {
     }
 
     #[proptest]
-    #[should_panic]
-    fn hash_size_panics_if_size_too_large(#[strategy(HashSize::MAX + 1..)] n: usize) {
-        HashSize::new(n);
-    }
-
-    #[proptest]
     fn parsing_printed_hash_size_rounds_to_megabytes(h: HashSize) {
         assert_eq!(h.to_string().parse(), Ok(h >> 20 << 20));
     }
@@ -185,12 +179,6 @@ mod tests {
         #[strategy(ThreadCount::MIN..=ThreadCount::MAX)] n: usize,
     ) {
         assert_eq!(ThreadCount::new(n), n);
-    }
-
-    #[proptest]
-    #[should_panic]
-    fn thread_count_panics_if_count_too_large(#[strategy(ThreadCount::MAX + 1..)] n: usize) {
-        ThreadCount::new(n);
     }
 
     #[proptest]

--- a/lib/util/assume.rs
+++ b/lib/util/assume.rs
@@ -1,3 +1,5 @@
+use std::hint::assert_unchecked;
+
 /// A trait for types that can be assumed to be another type.
 pub trait Assume {
     /// The type of the assumed value.
@@ -5,6 +7,17 @@ pub trait Assume {
 
     /// Assume `Self` represents a value of `Self::Assumed`.
     fn assume(self) -> Self::Assumed;
+}
+
+impl Assume for bool {
+    type Assumed = ();
+
+    #[track_caller]
+    #[inline(always)]
+    fn assume(self) -> Self::Assumed {
+        // Definitely not safe, but we'll assume unit tests will catch everything.
+        unsafe { assert_unchecked(self) }
+    }
 }
 
 impl<T> Assume for Option<T> {

--- a/lib/util/binary.rs
+++ b/lib/util/binary.rs
@@ -1,4 +1,4 @@
-use crate::util::{Bits, Unsigned};
+use crate::util::{Assume, Bits, Unsigned};
 use std::fmt::Debug;
 
 /// Trait for types that can be encoded to binary.
@@ -36,7 +36,7 @@ impl<T: Binary<Bits: Default + Debug + Eq + PartialEq>> Binary for Option<T> {
             None => T::Bits::default(),
             Some(t) => {
                 let bits = t.encode();
-                debug_assert_ne!(bits, T::Bits::default());
+                (bits != T::Bits::default()).assume();
                 bits
             }
         }
@@ -72,11 +72,5 @@ mod tests {
         #[filter(#o != Some(Bits::default()))] o: Option<Bits<u8, 6>>,
     ) {
         assert_eq!(Option::decode(o.encode()), o);
-    }
-
-    #[proptest]
-    #[should_panic]
-    fn encoding_panics_on_aliasing() {
-        Some(Bits::<u8, 6>::default()).encode();
     }
 }

--- a/lib/util/bits.rs
+++ b/lib/util/bits.rs
@@ -102,12 +102,6 @@ mod tests {
     }
 
     #[proptest]
-    #[should_panic]
-    fn constructor_panics_if_value_is_too_wide(#[strategy(u8::ones(6)..)] n: u8) {
-        Bits::<_, 5>::new(n);
-    }
-
-    #[proptest]
     fn get_returns_raw_collection_of_bits(b: Bits<u8, 5>) {
         assert_eq!(b.get(), b.0);
     }
@@ -162,7 +156,7 @@ mod tests {
 
     #[proptest]
     #[should_panic]
-    fn pop_ignores_underflow(mut a: Bits<u8, 3>) {
+    fn pop_panics_on_underflow(mut a: Bits<u8, 3>) {
         a.pop::<u16, 9>();
     }
 


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -4       5    9000    2498    2599    3903   4449.5   49.4%   43.4% 
   1 Halogen-12.0                   27       9    3000     956     723    1321   1616.5   53.9%   44.0% 
   2 Pawn-3.0                       -5       9    3000     773     818    1409   1477.5   49.3%   47.0% 
   3 Willow-4.0                    -10      10    3000     870     957    1173   1456.5   48.5%   39.1%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:29s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     69     56     67     74     71     56     58     52     50     62     55     55     61     64     45    895
   Score   7741   7009   7817   8472   8003   7676   7326   6859   6111   7340   6556   6686   6945   7482   6577 108600
Score(%)   91.1   87.6   90.9   95.2   94.2   96.0   89.3   85.7   86.1   92.9   93.7   90.4   92.6   94.7   90.1   91.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 96.0%, "Re-Capturing"
2. STS 04, 95.2%, "Square Vacancy"
3. STS 14, 94.7%, "Queens and Rooks to the 7th rank"
4. STS 05, 94.2%, "Bishop vs Knight"
5. STS 11, 93.7%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 08, 85.7%, "Advancement of f/g/h Pawns"
2. STS 09, 86.1%, "Advancement of a/b/c Pawns"
3. STS 02, 87.6%, "Open Files and Diagonals"
4. STS 07, 89.3%, "Offer of Simplification"
5. STS 15, 90.1%, "Avoid Pointless Exchange"
```