### PR TITLE
Lower timer precision to reduce syscall overhead

### DIFF
--- a/lib/search/control.rs
+++ b/lib/search/control.rs
@@ -18,8 +18,10 @@ impl Control<'_> {
     /// A reference to the timer.
     #[inline(always)]
     pub fn timer(&self) -> &Timer {
+        static INFINITE: Timer = Timer::infinite();
+
         match self {
-            Control::Unlimited => &const { Timer::infinite() },
+            Control::Unlimited => &INFINITE,
             Control::Limited(_, timer, _) => timer,
         }
     }


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -4       5    9000    2521    2631    3848   4445.0   49.4%   42.8% 
   1 Halogen-12.0                   29       9    3000     985     732    1283   1626.5   54.2%   42.8% 
   2 Pawn-3.0                       -8       9    3000     786     855    1359   1465.5   48.9%   45.3% 
   3 Willow-4.0                     -9      10    3000     860     934    1206   1463.0   48.8%   40.2%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:28s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     67     58     65     70     72     55     64     56     49     65     56     54     61     63     50    905
   Score   7634   7094   7651   8240   7937   7538   7535   6873   6145   7472   6574   6773   6850   7272   6614 108202
Score(%)   89.8   88.7   89.0   92.6   93.4   94.2   91.9   85.9   86.5   94.6   93.9   91.5   91.3   92.1   90.6   91.1

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 10, 94.6%, "Simplification"
2. STS 06, 94.2%, "Re-Capturing"
3. STS 11, 93.9%, "Activity of the King"
4. STS 05, 93.4%, "Bishop vs Knight"
5. STS 04, 92.6%, "Square Vacancy"

:: Top 5 STS with low result ::
1. STS 08, 85.9%, "Advancement of f/g/h Pawns"
2. STS 09, 86.5%, "Advancement of a/b/c Pawns"
3. STS 02, 88.7%, "Open Files and Diagonals"
4. STS 03, 89.0%, "Knight Outposts"
5. STS 01, 89.8%, "Undermining"
```