### PR TITLE
Simplify fn Engine::search to always return full PV line

### DIFF
--- a/benches/search.rs
+++ b/benches/search.rs
@@ -17,7 +17,7 @@ fn bench(reps: u64, options: &Options, limits: &Limits) -> Duration {
         let stopper = Trigger::armed();
         let pos = Evaluator::default();
         let timer = Instant::now();
-        e.search::<1>(&pos, limits, &stopper);
+        e.search(&pos, limits, &stopper);
         time += timer.elapsed();
     }
 

--- a/lib/search/pv.rs
+++ b/lib/search/pv.rs
@@ -1,4 +1,5 @@
-use crate::{chess::Move, search::Score};
+use crate::search::{Depth, Score};
+use crate::{chess::Move, util::Integer};
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops::{Neg, Shr};
@@ -11,7 +12,7 @@ use proptest::{collection::vec, prelude::*};
 /// [principal variation]: https://www.chessprogramming.org/Principal_Variation
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
-pub struct Pv<const N: usize> {
+pub struct Pv<const N: usize = { Depth::MAX as _ }> {
     score: Score,
     #[cfg_attr(test, strategy(vec(any::<Move>(), ..=N).prop_map(|ms| {
         let mut moves = [None; N];


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -6       5    9000    2454    2600    3946   4427.0   49.2%   43.8% 
   1 Halogen-12.0                   29       9    3000     974     720    1306   1627.0   54.2%   43.5% 
   2 Pawn-3.0                       -2       9    3000     807     826    1367   1490.5   49.7%   45.6% 
   3 Willow-4.0                    -10       9    3000     819     908    1273   1455.5   48.5%   42.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     67     62     68     72     72     56     61     55     49     64     53     52     61     61     48    901
   Score   7590   7252   7851   8345   8094   7606   7397   6990   6057   7433   6550   6663   6847   7341   6559 108575
Score(%)   89.3   90.7   91.3   93.8   95.2   95.1   90.2   87.4   85.3   94.1   93.6   90.0   91.3   92.9   89.8   91.4

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 05, 95.2%, "Bishop vs Knight"
2. STS 06, 95.1%, "Re-Capturing"
3. STS 10, 94.1%, "Simplification"
4. STS 04, 93.8%, "Square Vacancy"
5. STS 11, 93.6%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 09, 85.3%, "Advancement of a/b/c Pawns"
2. STS 08, 87.4%, "Advancement of f/g/h Pawns"
3. STS 01, 89.3%, "Undermining"
4. STS 15, 89.8%, "Avoid Pointless Exchange"
5. STS 12, 90.0%, "Center Control"
```