### PR TITLE
Remove time-to-move adjustment during aspiration windows

### DIFF
--- a/lib/chess/bitboard.rs
+++ b/lib/chess/bitboard.rs
@@ -124,7 +124,6 @@ impl Bitboard {
 
         #[cold]
         #[ctor::ctor]
-        #[optimize(size)]
         #[inline(never)]
         unsafe fn init() {
             let lines = LINES.get().as_mut_unchecked();
@@ -168,7 +167,6 @@ impl Bitboard {
 
         #[cold]
         #[ctor::ctor]
-        #[optimize(size)]
         #[inline(never)]
         unsafe fn init() {
             let segments = SEGMENTS.get().as_mut_unchecked();

--- a/lib/chess/castles.rs
+++ b/lib/chess/castles.rs
@@ -91,7 +91,6 @@ impl From<Square> for Castles {
 
         #[cold]
         #[ctor::ctor]
-        #[optimize(size)]
         #[inline(never)]
         unsafe fn init() {
             let castles = CASTLES.get().as_mut_unchecked();

--- a/lib/chess/piece.rs
+++ b/lib/chess/piece.rs
@@ -31,7 +31,6 @@ impl Piece {
 
         #[cold]
         #[ctor::ctor]
-        #[optimize(size)]
         #[inline(never)]
         unsafe fn init() {
             let bitboard = BITBOARDS.get().as_mut_unchecked();

--- a/lib/chess/zobrist.rs
+++ b/lib/chess/zobrist.rs
@@ -21,7 +21,6 @@ static ZOBRIST: SyncUnsafeCell<ZobristNumbers> = unsafe { MaybeUninit::zeroed().
 
 #[cold]
 #[ctor::ctor]
-#[optimize(size)]
 #[inline(never)]
 unsafe fn init() {
     let zobrist = ZOBRIST.get().as_mut_unchecked();

--- a/lib/lib.rs
+++ b/lib/lib.rs
@@ -3,7 +3,6 @@
     array_chunks,
     coverage_attribute,
     new_zeroed_alloc,
-    optimize_attribute,
     ptr_as_ref_unchecked,
     round_char_boundary,
     sync_unsafe_cell

--- a/lib/nnue.rs
+++ b/lib/nnue.rs
@@ -36,7 +36,6 @@ static NNUE: SyncUnsafeCell<Nnue> = unsafe { MaybeUninit::zeroed().assume_init()
 
 #[cold]
 #[ctor::ctor]
-#[optimize(size)]
 #[inline(never)]
 unsafe fn init() {
     let encoded = include_bytes!("nnue/nn.zst").as_slice();

--- a/lib/search/engine.rs
+++ b/lib/search/engine.rs
@@ -380,7 +380,6 @@ impl Engine {
         let mut pv = Pv::new(Score::lower(), []);
 
         'id: for depth in Depth::iter() {
-            let mut overtime = time.end - time.start;
             let mut draft = depth;
             let mut delta = 5i16;
 
@@ -399,7 +398,7 @@ impl Engine {
 
             'aw: loop {
                 delta = delta.saturating_mul(2);
-                if ctrl.timer().remaining() < Some(overtime) {
+                if ctrl.timer().remaining() < Some(time.end - time.start) {
                     break 'id;
                 }
 
@@ -409,14 +408,12 @@ impl Engine {
 
                 match partial.score() {
                     score if (-lower..Score::upper()).contains(&-score) => {
-                        overtime /= 2;
                         draft = depth;
                         upper = lower / 2 + upper / 2;
                         lower = score - delta;
                     }
 
                     score if (upper..Score::upper()).contains(&score) => {
-                        overtime = time.end - time.start;
                         draft = draft - 1;
                         upper = score + delta;
                         pv = partial;


### PR DESCRIPTION
### Gauntlet

> `cutechess-cli -tournament gauntlet -games 2 -rounds 1500 -openings file=engines/openings-6ply-1000.pgn plies=6 policy=round -concurrency 12 -ratinginterval 10 -resultformat wide -recover -engine conf=dev stderr=stderr.log -engine conf=Pawn-3.0 -engine conf=Halogen-12.0 -engine conf=Willow-4.0 -each tc=3+0.025 option.Hash=32 option.Threads=1`

```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw 
   0 dev                            -5       5    9000    2515    2641    3844   4437.0   49.3%   42.7% 
   1 Halogen-12.0                   30       9    3000     997     735    1268   1631.0   54.4%   42.3% 
   2 Willow-4.0                     -7      10    3000     864     921    1215   1471.5   49.0%   40.5% 
   3 Pawn-3.0                       -9       9    3000     780     859    1361   1460.5   48.7%   45.4%
```

### STS1-STS15_LAN_v6.epd

> `python sts_rating.py -f "./epd/STS1-STS15_LAN_v6.epd" -e dev -t 8 -h 256 --movetime 100 --maxpoint 100`

```
STS Rating v14.2
Engine: chessboard
Hash: 256, Threads: 8, time/pos: 0.100s

Number of positions in ./epd/STS1-STS15_LAN_v6.epd: 1188
Max score = 1188 x 100 = 118800
Test duration: 00h:02m:30s
Expected time to finish: 00h:02m:34s

  STS ID   STS1   STS2   STS3   STS4   STS5   STS6   STS7   STS8   STS9  STS10  STS11  STS12  STS13  STS14  STS15    ALL
  NumPos     85     80     86     89     85     80     82     80     71     79     70     74     75     79     73   1188
 BestCnt     65     64     65     74     70     55     60     58     50     60     55     58     59     57     51    901
   Score   7611   7351   7812   8392   7871   7561   7265   7157   6342   7278   6472   6939   6729   7037   6706 108523
Score(%)   89.5   91.9   90.8   94.3   92.6   94.5   88.6   89.5   89.3   92.1   92.5   93.8   89.7   89.1   91.9   91.3

:: STS ID and Titles ::
STS 01: Undermining
STS 02: Open Files and Diagonals
STS 03: Knight Outposts
STS 04: Square Vacancy
STS 05: Bishop vs Knight
STS 06: Re-Capturing
STS 07: Offer of Simplification
STS 08: Advancement of f/g/h Pawns
STS 09: Advancement of a/b/c Pawns
STS 10: Simplification
STS 11: Activity of the King
STS 12: Center Control
STS 13: Pawn Play in the Center
STS 14: Queens and Rooks to the 7th rank
STS 15: Avoid Pointless Exchange

:: Top 5 STS with high result ::
1. STS 06, 94.5%, "Re-Capturing"
2. STS 04, 94.3%, "Square Vacancy"
3. STS 12, 93.8%, "Center Control"
4. STS 05, 92.6%, "Bishop vs Knight"
5. STS 11, 92.5%, "Activity of the King"

:: Top 5 STS with low result ::
1. STS 07, 88.6%, "Offer of Simplification"
2. STS 14, 89.1%, "Queens and Rooks to the 7th rank"
3. STS 09, 89.3%, "Advancement of a/b/c Pawns"
4. STS 08, 89.5%, "Advancement of f/g/h Pawns"
5. STS 01, 89.5%, "Undermining"
```